### PR TITLE
allow real number as argument to `discount`

### DIFF
--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -46,6 +46,7 @@ end
 
 rate(c::Constant,time) = c.rate
 discount(c::Constant,time) = 1 / (1 + rate(c, time))^time
+discount(c::T,time) where {T <: Real} = discount(Constant(c),time)
 
 """
     Step(rates,times)
@@ -228,7 +229,7 @@ rate(yc,time) = yc.spline(time)
 """
     discount(yield,time)
 
-The discount factor for the `yield` from time zero through `time`.
+The discount factor for the `yield` from time zero through `time`. If yield is a `Real` number, will assume a `Constant` interest rate.
 """
 discount(yc,time) = 1 / (1 + rate(yc, time))^time
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Test
 
         @testset "constant discount time: $time" for time in [0,0.5,1,10]
             @test discount(yield, time) ≈ 1 / (1.05)^time 
+            @test discount(0.05,time) ≈ 1 / (1.05)^time 
             @test accumulate(yield, time) ≈ 1 * 1.05^time
             @test rate(yield, time) == 0.05
         end


### PR DESCRIPTION
Avoids the need to use the `Constant` in `discount(Constant(0.05),1)`