### PR TITLE
Treasury fix

### DIFF
--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -185,9 +185,9 @@ function USTreasury(rates, maturities)
     for (i, (rate, mat)) in enumerate(zip(rates, maturities))
         
         if mat <= 1 
-            z[i] = rate
+            z[i] = (1 + rate * mat) ^ (1/mat) -1
         else
-            # uses spline b/c of common, but uneven maturities often present under 1 year.
+            # uses interpolation b/c of common, but uneven maturities often present under 1 year.
             curve = linear_interp(maturities, z)
             pmts = [rate / 2 for t in 0.5:0.5:mat] # coupons only
             pmts[end] += 1 # plus principal

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -178,6 +178,11 @@ function Forward(rate_vector, times)
     return Zero(1 ./ disc_v.^(1 ./ times) .- 1, times)
 end
 
+"""
+    USTreasury(rates,maturities)
+
+Takes CMT yields (bond equivalent), and assumes that instruments <= one year maturity pay no coupons and that the rest pay semi-annual.
+"""
 function USTreasury(rates, maturities)
     z = zeros(length(rates))
 
@@ -222,7 +227,7 @@ end
 """
     rate(yield,time)
 
-The spot rate at `time` for the given `yield`.
+The annual effective spot rate at `time` for the given `yield`.
 """
 rate(yc,time) = yc.spline(time)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,7 +179,7 @@ using Test
 
         curve = Yields.USTreasury(YTM, maturity)
 
-        @test rate(curve, 0.5) ≈ 0.04
+        @test rate(curve, 0.5) ≈ (1 + 0.04/2) ^ 2 - 1
         @test rate(curve, 1.0) ≈ 0.043
 
         # need more future tests, but need validating source...
@@ -187,10 +187,17 @@ using Test
     end
 
     @testset "actual cmt treasury" begin
-        
-        cmt  = [0.12,0.15,0.14,0.17,0.17,0.17,0.19,0.30,0.49,0.64,1.15,1.37] ./ 100
-        mats =  [1 / 12,2 / 12,3 / 12,6 / 12,1,2,3,5,7,10,20,30]
+        # Hull 10th ed, 4.7
+        cmt  = [1.6064,2.0202,2.2495,2.2949,2.4238] ./ 100
+        mats =  [.25,.5,1.,1.5,2.]
+        curve = Yields.USTreasury(cmt,mats)
 
+        # rates in book are continuous, but Yields focuses on annual
+        @test log(rate(curve,0.25)+1) ≈ 0.01603 atol=0.001
+        @test log(rate(curve,0.5 )+1) ≈ 0.02010 atol=0.001
+        @test log(rate(curve,1.0 )+1) ≈ 0.02225 atol=0.001
+        @test log(rate(curve,1.5 )+1) ≈ 0.02284 atol=0.001
+        @test log(rate(curve,2.0 )+1) ≈ 0.02416 atol=0.001
     end
 
 


### PR DESCRIPTION
Bills were previsouly treated as if they were spot rates, not bond equivalent as appears to be the standard in https://home.treasury.gov/policy-issues/financing-the-government/interest-rate-statistics/treasury-yield-curve-methodology