### PR TITLE
call first value from `rates`, not the function `rate`

### DIFF
--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -308,7 +308,7 @@ Construct a yield curve with given zero-coupon spot `rates` at the given `maturi
 """
 function Zero(rates, maturities)
     # bump to a constant yield if only given one rate
-    length(rates) == 1 && return Constant(rate[1])
+    length(rates) == 1 && return Constant(first(rates))
     return YieldCurve(
         rates,
         maturities,


### PR DESCRIPTION
Use JET to statically analyze for potential issues. 

Current status:

```julia-repl
julia> report_package(Yields)
[toplevel-info] virtualized the context of Main (took 0.08 sec)
[toplevel-info] entered into /Users/alec/.julia/dev/Yields/src/Yields.jl
[toplevel-info]  exited from /Users/alec/.julia/dev/Yields/src/Yields.jl (took 0.628 sec)
[toplevel-info] analyzing from top-level definitions ... 84/84
═════ 7 possible errors found ═════
┌ @ /Users/alec/.julia/dev/Yields/src/Yields.jl:272 Yields.findfirst(#1, Base.getproperty(y, :times))
│┌ @ array.jl:1966 Base.findnext(testf, A, Base.first(Base.keys(A)))
││┌ @ /Users/sabae/src/julia/usr/share/julia/stdlib/v1.7/SparseArrays/src/abstractsparse.jl:85 SparseArrays.invoke(SparseArrays.findnext, Core.apply_type(SparseArrays.Tuple, SparseArrays.Function, SparseArrays.Any, SparseArrays.Any), f, v, i)
│││┌ @ array.jl:1918 Base.nextind(A, i)
││││┌ @ multidimensional.jl:155 Base.IteratorsMD.inc(Base.getproperty(i, :I), Base.getproperty(iter, :indices))
│││││┌ @ multidimensional.jl:391 Base.IteratorsMD.__inc(state, indices)
││││││┌ @ multidimensional.jl:414 Core.typeassert(t2, Core.apply_type(Base.IteratorsMD.Tuple, Base.IteratorsMD.OrdinalRangeInt, Base.IteratorsMD.OrdinalRangeInt, Core.apply_type(Base.IteratorsMD.Vararg, Base.IteratorsMD.OrdinalRangeInt)))
│││││││ invalid builtin function call: Core.typeassert(t2::Tuple{Base.OneTo{Int64}}, Core.apply_type(Base.IteratorsMD.Tuple, Base.IteratorsMD.OrdinalRangeInt, Base.IteratorsMD.OrdinalRangeInt, Core.apply_type(Base.IteratorsMD.Vararg, Base.IteratorsMD.OrdinalRangeInt)::Core.TypeofVararg)::Type{Tuple{OrdinalRange{Int64, Int64}, OrdinalRange{Int64, Int64}, Vararg{OrdinalRange{Int64, Int64}}}})
││││││└───────────────────────────
┌ @ /Users/alec/.julia/dev/Yields/src/Yields.jl:312 Yields.linear_interp(Base.vcat(0.0, maturities), Base.vcat(1.0, Base.materialize(Base.broadcasted(Yields.discount, Base.broadcasted(Yields.Constant, rates), maturities))))
│┌ @ /Users/alec/.julia/dev/Yields/src/Yields.jl:591 Interpolations.interpolate(Core.tuple(xs), ys, Interpolations.Gridded(Interpolations.Linear()))
││┌ @ /Users/alec/.julia/packages/Interpolations/qHlUr/src/gridded/gridded.jl:83 Interpolations.interpolate(Interpolations.tweight(A), Interpolations.tcoef(A), knots, A, it)
│││┌ @ /Users/alec/.julia/packages/Interpolations/qHlUr/src/gridded/gridded.jl:66 Interpolations.GriddedInterpolation(_, knots, A, it)
││││┌ @ /Users/alec/.julia/packages/Interpolations/qHlUr/src/gridded/gridded.jl:32 Interpolations.check_gridded(it, knots, Interpolations.axes(A))
│││││┌ @ /Users/alec/.julia/packages/Interpolations/qHlUr/src/gridded/gridded.jl:52 Interpolations.check_gridded(Interpolations.getrest(itpflag), Base.tail(knots), Base.tail(axs))
││││││┌ @ /Users/alec/.julia/packages/Interpolations/qHlUr/src/gridded/gridded.jl:43 Base.getindex(knots, 1)
│││││││┌ @ tuple.jl:29 Base.getfield(t, i, $(Expr(:boundscheck)))
││││││││ invalid builtin function call: Base.getfield(t::Tuple{}, i::Int64, $(Expr(:boundscheck)))
│││││││└───────────────
┌ @ /Users/alec/.julia/dev/Yields/src/Yields.jl:346 Base.getindex(Yields.rate, 1)
│ no matching method found for call signature (Tuple{typeof(getindex), typeof(Yields.rate), Int64}): Base.getindex(Yields.rate, 1)
└───────────────────────────────────────────────────
┌ @ /Users/alec/.julia/dev/Yields/src/Yields.jl:388 Yields.map(#5, Yields.zip(rates, maturities))
│┌ @ abstractarray.jl:2878 Base.collect(Base.Generator(f, A))
││┌ @ array.jl:715 Base.collect_to_with_first!(Base._array_for(Base.typeof(v1), Base.getproperty(itr, :iter), isz), v1, itr, st)
│││┌ @ array.jl:739 Base.grow_to!(dest, itr, st)
││││┌ @ dict.jl:153 Base.indexed_iterate(Core.getfield(Base.indexed_iterate(y, 1), 1), 1)
│││││┌ @ tuple.jl:92 Base.iterate(I)
││││││ no matching method found for call signature (Tuple{typeof(iterate), Yields.Rate}): Base.iterate(I::Yields.Rate)
│││││└───────────────
┌ @ /Users/alec/.julia/dev/Yields/src/Yields.jl:396 Yields.CMT(rs, maturities)
│┌ @ /Users/alec/.julia/dev/Yields/src/Yields.jl:400 Base.collect(Base.Generator(#7, maturities))
││┌ @ array.jl:708 Base.grow_to!(Core.apply_type(Base.Vector, et)(), itr)
│││┌ @ array.jl:774 Base.push!(dest2, Base.getindex(y, 1))
││││┌ @ array.jl:968 Base.convert(_, item)
│││││ no matching method found for call signature (Tuple{typeof(convert), Type{Float64}, Nothing}): Base.convert(_::Type{Float64}, item::Nothing)
││││└────────────────
││┌ @ array.jl:715 Base.collect_to_with_first!(Base._array_for(Base.typeof(v1), Base.getproperty(itr, :iter), isz), v1, itr, st)
│││┌ @ array.jl:739 Base.grow_to!(dest, itr, st)
││││┌ @ dict.jl:153 Base.indexed_iterate(Core.getfield(Base.indexed_iterate(y, 1), 1), 1)
│││││┌ @ tuple.jl:92 Base.iterate(I)
││││││ no matching method found for call signature (Tuple{typeof(iterate), Nothing}): Base.iterate(I::Nothing)
│││││└───────────────
││││┌ @ dict.jl:153 Base.indexed_iterate(Core.getfield(Base.indexed_iterate(y, 1), 1), 2, _6)
│││││┌ @ tuple.jl:97 Base.iterate(I, state)
││││││ no matching method found for call signature (Tuple{typeof(iterate), Nothing, Nothing}): Base.iterate(I::Nothing, state::Nothing)
│││││└───────────────
(included_files = Set(["/Users/alec/.julia/dev/Yields/src/Yields.jl"]), nreported = 7)
```