### PR TITLE
Improve consistency of `rate` in API

### DIFF
--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -738,6 +738,28 @@ function accumulation(y::T, from, to) where {T <: AbstractYield}
 end
 accumulation(rate::Rate,from,to) = accumulation(Constant(rate), from, to)
 
+
+""" 
+    rate(curve,time)
+    rate(CompoundingFrequency,curve,time)
+
+Return the rate for the curve at the given timepoint. If a `CompoundingFrequency` (e.g. `Yields.Continuous()` or `Yields.Periodic(2)`) not given, will assume periodic compounding of `Yields.Periodic(1)` frequency
+"""
+rate(curve,time) = rate(Periodic(1),curve,time)
+function rate(cf::Periodic,curve,time)
+    v = discount(curve,time)
+    f = cf.frequency
+    i = -f*v^(-1/(f*time))*(-1 + v^(1/(f*time)))
+    return Rate(i,cf)
+end
+function rate(cf::Continuous,curve,time)
+    v = discount(curve,time)
+    v = 1 / exp(r*time)
+    r = log(1/v)/time
+    return Rate(r,cf)
+end
+
+
 ## Curve Manipulations
 struct RateCombination <: AbstractYield
     r1


### PR DESCRIPTION
I was experimenting with SmithWilson curves and wanted to extract the rate at a certain timepoint of the curve. I realized that the function `rate` isn't consistenty 1) defined for curves or 2) what can be expected to return.

1. `rate` wasn't defined for most curves

2. the return type isn't consistent

calling `rate` on a `Rate` returns the scalar value attached to the `Rate`, whereas calling a rate on the hithertoo defined curves returns a `Rate`, e.g. `Rate(0.03,Periodic(2))`

This PR proposes the following consistency:

- `rate(...)` will always return a `Rate` which is proper because any yield has an associated compounding convention, otherwise it's incomplete information.
  `rate(r::Rate,time)` will return itself, `r`
  `rate(curve::AbstractYield,time)` will return a `Rate` with the implicit default of `rate(Periodic(1),curve,time)`

- to get the scalar, unitless value out of a rate (e.g. `Rate(0.03,Periodic(2))` -> `0.03) would follow the convention in [Unitful.jl](http://painterqubits.github.io/Unitful.jl/stable/conversion/#Dimensionless-quantities) to explictly ask for it: `convert(Float64,Rate(0.03,Periodic(2)))` -> `0.03`
  - Also provide `Yields.value(rate)` which returns the value as well

