### PR TITLE
Improve performance substantially by parameterizing types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.1'
           - '1.5'
+          - '1.6'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   - push
   - pull_request
 jobs:
-  test:
+  test: # from https://github.com/simeonschaub/OptionalArgChecks.jl/blob/457488ef04ed68a37aff10af1cb3909f47a8230c/.github/workflows/ci.yml#L23-L37
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -16,14 +16,9 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        experimental: [false]
         arch:
           - x64
-        include:
-          - version: 'nightly'
-            arch: x64
-            os: ubuntu-latest
-            experimental: true
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -31,15 +26,12 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@latest
+        continue-on-error: ${{ matrix.version == 'nightly' }}
       - uses: julia-actions/julia-runtest@latest
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./lcov.info
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: ${{ matrix.version == 'nightly' }}
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       
   docs:
     name: Documentation
@@ -48,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.5'
+          version: '1.6'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Yields"
 uuid = "d7e99b2f-e7f3-4d9e-9f01-2338fc023ad3"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
-version = "0.7.1"
+version = "0.8.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [compat]
 ForwardDiff = "^0.10"
 Interpolations = "^0.12.4, 0.13"
-julia = "^1.1"
+julia = "^1.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -731,9 +731,21 @@ discount(rate::Rate{<:Real,<:CompoundingFrequency},to) = discount(Constant(rate)
 
 discount(yc,from,to) = discount(yc, to) / discount(yc, from)
 
+"""
+    forward(curve,from,to,CompoundingFrequency=Periodic(1))
+
+The forward `Rate` implied by the curve between times `from` and `to`.
+"""
     function forward(yc, from, to)
-    return (accumulation(yc, to) / accumulation(yc, from))^(1 / (to - from)) - 1
+    return forward(yc,from,to,Periodic(1))
 end
+
+function forward(yc,from,to,cf::T) where {T<:CompoundingFrequency}
+
+    r  = Periodic((accumulation(yc, to) / accumulation(yc, from))^(1 / (to - from)) - 1,1)
+    return convert(cf,r)
+end
+
 function forward(yc, from)
     to = from + 1
     return forward(yc, from, to)

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -198,10 +198,10 @@ abstract type AbstractYield end
 # make interest curve broadcastable so that you can broadcast over multiple`time`s in `interest_rate`
 Base.Broadcast.broadcastable(ic::T) where {T<:AbstractYield} = Ref(ic)
 
-struct YieldCurve <: AbstractYield
-    rates
-    maturities
-    discount # discount function for time
+struct YieldCurve{T,U,V} <: AbstractYield
+    rates::T
+    maturities::U
+    discount::V # discount function for time
 end
 
 """
@@ -767,10 +767,10 @@ end
 accumulation(rate::Rate{<:Real,<:CompoundingFrequency}, from, to) = accumulation(Constant(rate), from, to)
 
 ## Curve Manipulations
-struct RateCombination <: AbstractYield
-    r1
-    r2
-    op
+struct RateCombination{T,U,V} <: AbstractYield
+    r1::T
+    r2::U
+    op::V
 end
 
 rate(rc::RateCombination, time) = rc.op(rate(rc.r1, time), rate(rc.r2, time))

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -6,10 +6,10 @@ using LinearAlgebra
 
 # don't export type, as the API of Yields.Zero is nicer and 
 # less polluting than Zero and less/equally verbose as ZeroYieldCurve or ZeroCurve
-export rate, discount, accumulation,forward, Yield, Rate, rate, spot
+export rate, discount, accumulation, forward, Yield, Rate, rate, spot
 
 abstract type CompoundingFrequency end
-Base.Broadcast.broadcastable(x::T) where {T <: CompoundingFrequency} = Ref(x) 
+Base.Broadcast.broadcastable(x::T) where {T<:CompoundingFrequency} = Ref(x)
 
 """ 
     Continuous()
@@ -76,7 +76,7 @@ Rate(0.01, Periodic(2))
 
 See also: [`Continuous`](@ref)
 """
-Periodic(x,frequency) = Rate(x, Periodic(frequency))
+Periodic(x, frequency) = Rate(x, Periodic(frequency))
 
 struct Rate{N<:Real,T<:CompoundingFrequency}
     value::N
@@ -121,7 +121,7 @@ Rate(0.01, Continuous())
 ```
 """
 Rate(rate) = Rate(rate, Periodic(1))
-Rate(x,frequency::T) where {T <: Real} = isinf(frequency) ? Rate(x, Continuous()) : Rate(x, Periodic(frequency))
+Rate(x, frequency::T) where {T<:Real} = isinf(frequency) ? Rate(x, Continuous()) : Rate(x, Periodic(frequency))
 
 """
     convert(T::CompoundingFrequency,r::Rate)
@@ -141,7 +141,7 @@ julia> convert(Continuous(),r)
 Rate(0.009995835646701251, Continuous())
 ```
 """
-function Base.convert(T::CompoundingFrequency,r::Rate{<:Real,<:CompoundingFrequency}) 
+function Base.convert(T::CompoundingFrequency, r::Rate{<:Real,<:CompoundingFrequency})
     convert(T, r, r.compounding)
 end
 function Base.convert(to::Continuous, r, from::Continuous)
@@ -158,24 +158,24 @@ end
 
 function Base.convert(to::Periodic, r, from::Periodic)
     c = convert(Continuous(), r, from)
-return convert(to, c, Continuous())
+    return convert(to, c, Continuous())
 end
 
-function rate(r::Rate{<:Real,<:CompoundingFrequency}) 
+function rate(r::Rate{<:Real,<:CompoundingFrequency})
     r.value
 end
 
-function Base.isapprox(a::Rate{N,T},b::Rate{N,T};atol::Real=0, rtol::Real=atol>0 ? 0 : √eps()) where {T<:Periodic,N<:Real}
-    return (a.compounding.frequency == b.compounding.frequency) && isapprox(rate(a), rate(b);atol,rtol)
+function Base.isapprox(a::Rate{N,T}, b::Rate{N,T}; atol::Real = 0, rtol::Real = atol > 0 ? 0 : √eps()) where {T<:Periodic,N<:Real}
+    return (a.compounding.frequency == b.compounding.frequency) && isapprox(rate(a), rate(b); atol, rtol)
 end
 
-function Base.isapprox(a::Rate{N,T},b::Rate{N,T};atol::Real=0, rtol::Real=atol>0 ? 0 : √eps()) where {T<:Continuous,N<:Real}
-    return isapprox(rate(a), rate(b);atol,rtol)
+function Base.isapprox(a::Rate{N,T}, b::Rate{N,T}; atol::Real = 0, rtol::Real = atol > 0 ? 0 : √eps()) where {T<:Continuous,N<:Real}
+    return isapprox(rate(a), rate(b); atol, rtol)
 end
 
 # the fallback for rates not of the same type
-function Base.isapprox(a::T,b::N;atol::Real=0, rtol::Real=atol>0 ? 0 : √eps()) where {T<:Rate,N<:Rate}
-    return isapprox(convert(b.compounding,a),b;atol,rtol)
+function Base.isapprox(a::T, b::N; atol::Real = 0, rtol::Real = atol > 0 ? 0 : √eps()) where {T<:Rate,N<:Rate}
+    return isapprox(convert(b.compounding, a), b; atol, rtol)
 end
 
 """
@@ -196,7 +196,7 @@ It can be be constructed via:
 abstract type AbstractYield end
 
 # make interest curve broadcastable so that you can broadcast over multiple`time`s in `interest_rate`
-Base.Broadcast.broadcastable(ic::T) where {T <: AbstractYield} = Ref(ic) 
+Base.Broadcast.broadcastable(ic::T) where {T<:AbstractYield} = Ref(ic)
 
 struct YieldCurve <: AbstractYield
     rates
@@ -210,7 +210,7 @@ end
 
 Return the zero rate for the curve at the given time. If not specified, will use `Periodic(1)` compounding.
 """
-Base.zero(c::YieldCurve,time) = zero(c, time, Periodic(1))
+Base.zero(c::YieldCurve, time) = zero(c, time, Periodic(1))
 function Base.zero(c::YieldCurve, time, cf::Periodic)
     d = discount(c, time)
     i = Rate(cf.frequency * (d^(-1 / (time * cf.frequency)) - 1), cf)
@@ -241,19 +241,19 @@ struct Constant{T} <: AbstractYield
     rate::T
 end
 
-function Constant(rate::T) where {T <: Real}
+function Constant(rate::T) where {T<:Real}
     return Constant(Rate(rate, Periodic(1)))
 end
 
 rate(c::Constant) = c.rate
-rate(c::Constant,time) = c.rate
-discount(c::T,time) where {T <: Real} = discount(Constant(c), time)
-discount(r::Constant,time) = 1 / accumulation(r, time)
+rate(c::Constant, time) = c.rate
+discount(c::T, time) where {T<:Real} = discount(Constant(c), time)
+discount(r::Constant, time) = 1 / accumulation(r, time)
 
-accumulation(r::Constant,time) = accumulation(r.rate.compounding, r, time)
-accumulation(c::T,time) where {T >: Real} = accumulation(Constant(c), time)
-accumulation(::Continuous,r::Constant,time) = exp(rate(r.rate) * time)
-accumulation(::Periodic,r::Constant,time) = (1 + rate(r.rate) / r.rate.compounding.frequency)^(r.rate.compounding.frequency * time)
+accumulation(r::Constant, time) = accumulation(r.rate.compounding, r, time)
+accumulation(c::T, time) where {T>:Real} = accumulation(Constant(c), time)
+accumulation(::Continuous, r::Constant, time) = exp(rate(r.rate) * time)
+accumulation(::Periodic, r::Constant, time) = (1 + rate(r.rate) / r.rate.compounding.frequency)^(r.rate.compounding.frequency * time)
 
 """
     Step(rates,times)
@@ -298,15 +298,15 @@ function discount(y::Step, time)
         return v
     end
 
-        for i in 2:length(y.times)
+    for i = 2:length(y.times)
 
         if y.times[i] >= time
             # take partial discount and break
-            v /= (1 + y.rates[i])^(time - y.times[i - 1])
+            v /= (1 + y.rates[i])^(time - y.times[i-1])
             break
         else
             # take full discount and continue
-            v /=  (1 + y.rates[i])^(y.times[i] - y.times[i - 1])
+            v /= (1 + y.rates[i])^(y.times[i] - y.times[i-1])
         end
 
     end
@@ -326,7 +326,7 @@ function Zero(rates, maturities)
     return YieldCurve(
         rates,
         maturities,
-        linear_interp([0.;maturities], [1.;discount.(Constant.(rates), maturities)])
+        linear_interp([0.0; maturities], [1.0; discount.(Constant.(rates), maturities)])
     )
 end
 
@@ -360,16 +360,16 @@ function Par(rates::Vector{<:Rate}, maturities)
         return Constant(rate[1])
     end
     return YieldCurve(
-            rates,
-            maturities,
-            # assume that maturities less than or equal to 12 months are settled once, otherwise semi-annual
-            # per Hull 4.7
-            bootstrap(rates, maturities, [m <= 1 ? nothing : 1 / r.compounding.frequency for (r, m) in zip(rates, maturities)])
-        )
+        rates,
+        maturities,
+        # assume that maturities less than or equal to 12 months are settled once, otherwise semi-annual
+        # per Hull 4.7
+        bootstrap(rates, maturities, [m <= 1 ? nothing : 1 / r.compounding.frequency for (r, m) in zip(rates, maturities)])
+    )
 end
 
-function Par(rates::Vector{T}, maturities) where {T <: Real}
-    return Par(Rate.(rates), maturities)  
+function Par(rates::Vector{T}, maturities) where {T<:Real}
+    return Par(Rate.(rates), maturities)
 end
 
 
@@ -381,15 +381,15 @@ Takes a vector of 1-period forward rates and constructs a discount curve.
 function Forward(rates, maturities)
     # convert to zeros and pass to Zero
     disc_v = similar(rates)
-    v = 1.
-    
-    for i in 1:length(rates)
-        Δt = maturities[i] - (i == 1 ? 0 : maturities[i - 1])
+    v = 1.0
+
+    for i = 1:length(rates)
+        Δt = maturities[i] - (i == 1 ? 0 : maturities[i-1])
         v *= discount(Constant(rates[i]), Δt)
         disc_v[i] = v
     end
 
-    z = (1. ./ disc_v).^( 1 ./ maturities) .- 1 # convert disc_v to zero
+    z = (1.0 ./ disc_v) .^ (1 ./ maturities) .- 1 # convert disc_v to zero
     return Zero(z, maturities)
 end
 
@@ -398,7 +398,7 @@ Forward(rates) = Forward(rates, collect(1:length(rates)))
 """
 Takes CMT yields (bond equivalent), and assumes that instruments <= one year maturity pay no coupons and that the rest pay semi-annual.
 """
-function CMT(rates::Vector{T}, maturities) where {T <: Real}
+function CMT(rates::Vector{T}, maturities) where {T<:Real}
     rs = map(zip(rates, maturities)) do (r, m)
         if m <= 1
             Rate(r, Periodic(1 / m))
@@ -412,21 +412,21 @@ end
 
 function CMT(rates::Vector{<:Rate}, maturities)
     return YieldCurve(
-            rates,
-            maturities,
-            # assume that maturities less than or equal to 12 months are settled once, otherwise semi-annual
-            # per Hull 4.7
-            bootstrap(rates, maturities, [m <= 1 ? nothing : 0.5 for m in maturities])
-        )
+        rates,
+        maturities,
+        # assume that maturities less than or equal to 12 months are settled once, otherwise semi-annual
+        # per Hull 4.7
+        bootstrap(rates, maturities, [m <= 1 ? nothing : 0.5 for m in maturities])
+    )
 end
-    
+
 
 """
     OIS(rates,maturities)
 Takes Overnight Index Swap rates, and assumes that instruments <= one year maturity are settled once and other agreements are settled quarterly with a corresponding CompoundingFrequency
 
 """
-function OIS(rates::Vector{T}, maturities) where {T <: Real}
+function OIS(rates::Vector{T}, maturities) where {T<:Real}
     rs = map(zip(rates, maturities)) do (r, m)
         if m <= 1
             Rate(r, Periodic(1 / m))
@@ -486,9 +486,9 @@ struct SwapQuote <: ObservableQuote
     yield
     maturity
     frequency
-    function SwapQuote(yield,maturity,frequency)
+    function SwapQuote(yield, maturity, frequency)
         frequency <= 0 && throw(DomainError("Payment frequency must be positive"))
-        return new(yield,maturity,frequency)
+        return new(yield, maturity, frequency)
     end
 end
 
@@ -516,9 +516,9 @@ struct BulletBondQuote <: ObservableQuote
     maturity
     frequency
 
-    function BulletBondQuote(yield,maturity,price,frequency)
+    function BulletBondQuote(yield, maturity, price, frequency)
         frequency <= 0 && throw(DomainError("Payment frequency must be positive"))
-        return new(yield,maturity,price,frequency)
+        return new(yield, maturity, price, frequency)
     end
 end
 
@@ -543,14 +543,14 @@ Required keyword arguments:
 - `ufr` is the Ultimate Forward Rate, the forward interest rate to which the yield curve tends, in continuous compounding convention. 
 - `α` is the parameter that governs the speed of convergence towards the Ultimate Forward Rate. It can be typed with `\\alpha[TAB]`
 """
-    struct SmithWilson{TU <: AbstractVector,TQb <: AbstractVector} <: AbstractYield
+struct SmithWilson{TU<:AbstractVector,TQb<:AbstractVector} <: AbstractYield
     u::TU
     qb::TQb
     ufr
     α
 
     # Inner constructor ensures that vector lengths match
-    function SmithWilson{TU,TQb}(u, qb; ufr, α) where {TU <: AbstractVector,TQb <: AbstractVector}
+    function SmithWilson{TU,TQb}(u, qb; ufr, α) where {TU<:AbstractVector,TQb<:AbstractVector}
         if length(u) != length(qb)
             throw(DomainError("Vectors u and qb in SmithWilson must have equal length"))
         end
@@ -558,7 +558,7 @@ Required keyword arguments:
     end
 end
 
-SmithWilson(u::TU, qb::TQb;ufr, α) where {TU <: AbstractVector,TQb <: AbstractVector} = SmithWilson{TU,TQb}(u, qb; ufr=ufr, α=α)
+SmithWilson(u::TU, qb::TQb; ufr, α) where {TU<:AbstractVector,TQb<:AbstractVector} = SmithWilson{TU,TQb}(u, qb; ufr = ufr, α = α)
 
 """
     H_ordered(α, t_min, t_max)
@@ -566,7 +566,7 @@ SmithWilson(u::TU, qb::TQb;ufr, α) where {TU <: AbstractVector,TQb <: AbstractV
 The Smith-Wilson H function with ordered arguments (for better performance than using min and max).
 """
 function H_ordered(α, t_min, t_max)
-    return α * t_min + exp(-α * t_max) * sinh(-α * t_min) 
+    return α * t_min + exp(-α * t_max) * sinh(-α * t_min)
 end
 
 """
@@ -592,11 +592,11 @@ Base.zero(sw::SmithWilson, t, cf::CompoundingFrequency) = convert(cf, zero(sw, t
 
 function SmithWilson(times::AbstractVector, cashflows::AbstractMatrix, prices::AbstractVector; ufr, α)
     Q = Diagonal(exp.(-ufr * times)) * cashflows
-    q = vec(sum(Q, dims=1))  # We want q to be a column vector
+    q = vec(sum(Q, dims = 1))  # We want q to be a column vector
     QHQ = Q' * H(α, times) * Q
     b = QHQ \ (prices - q)
     Qb = Q * b
-    return SmithWilson(times, Qb; ufr=ufr, α=α)
+    return SmithWilson(times, Qb; ufr = ufr, α = α)
 end
 
 """ 
@@ -629,13 +629,13 @@ function cashflows(interests, maturities, frequencies)
     floored_mats = floor.(maturities ./ timestep) .* timestep
     times = timestep:timestep:maximum(floored_mats)
     # we need to determine the coupons in relation to the payment date, not time zero
-    time_adj =  floored_mats .% fq 
+    time_adj = floored_mats .% fq
 
     cashflows = [
         # if on a coupon date and less than maturity, pay coupon
-        ((((t + time_adj[instrument]) % fq[instrument] ≈ 0) && t <= floored_mats[instrument]) ? interests[instrument] / frequencies[instrument]  : 0.) + 
-        (t ≈ floored_mats[instrument] ? 1.0 : 0.) # add maturity payment
-        for t in times, instrument in 1:length(interests)
+        ((((t + time_adj[instrument]) % fq[instrument] ≈ 0) && t <= floored_mats[instrument]) ? interests[instrument] / frequencies[instrument] : 0.0) +
+        (t ≈ floored_mats[instrument] ? 1.0 : 0.0) # add maturity payment
+        for t in times, instrument = 1:length(interests)
     ]
 
     return cashflows
@@ -653,47 +653,47 @@ function SmithWilson(zcq::Vector{ZeroCouponQuote}; ufr, α)
     n = length(zcq)
     maturities = [q.maturity for q in zcq]
     prices = [q.price for q in zcq]
-    return SmithWilson(maturities, Matrix{Float64}(I, n, n), prices; ufr=ufr, α=α)
+    return SmithWilson(maturities, Matrix{Float64}(I, n, n), prices; ufr = ufr, α = α)
 end
 
 function SmithWilson(swq::Vector{SwapQuote}; ufr, α)
     times = timepoints(swq)
     cfs = cashflows(swq)
     ones(length(swq))
-    return SmithWilson(times, cfs, ones(length(swq)), ufr=ufr, α=α)
+    return SmithWilson(times, cfs, ones(length(swq)), ufr = ufr, α = α)
 end
 
 function SmithWilson(bbq::Vector{BulletBondQuote}; ufr, α)
     times = timepoints(bbq)
     cfs = cashflows(bbq)
     prices = [q.price for q in bbq]
-    return SmithWilson(times, cfs, prices, ufr=ufr, α=α)
+    return SmithWilson(times, cfs, prices, ufr = ufr, α = α)
 end
 
 # https://github.com/dpsanders/hands_on_julia/blob/master/during_sessions/Fractale%20de%20Newton.ipynb
 newton(f, f′, x) = x - f(x) / f′(x)
-function solve(g, g′, x0, max_iterations=100)
+function solve(g, g′, x0, max_iterations = 100)
     x = x0
 
     tolerance = 2 * eps(x0)
     iteration = 0
 
     while (abs(g(x) - 0) > tolerance && iteration < max_iterations)
-        x = newton(g, g′, x)        
+        x = newton(g, g′, x)
         iteration += 1
     end
 
     return x
 end
 
-function bootstrap(rates, maturities, settlement_frequency;interp_function=linear_interp)
+function bootstrap(rates, maturities, settlement_frequency; interp_function = linear_interp)
     settlement_frequency, maturities, rates
     discount_vec = zeros(length(rates)) # construct a placeholder discount vector matching maturities
     # we have to take the first rate as the starting point
     discount_vec[1] = discount(Constant(rates[1]), maturities[1])
 
-    for t in 2:length(maturities)
-        if isnothing(settlement_frequency[t]) 
+    for t = 2:length(maturities)
+        if isnothing(settlement_frequency[t])
             # no settlement before maturity
             discount_vec[t] = discount(Constant(rates[t]), maturities[t])
         else
@@ -701,9 +701,9 @@ function bootstrap(rates, maturities, settlement_frequency;interp_function=linea
             times = settlement_frequency[t]:settlement_frequency[t]:maturities[t]
             cfs = [rate(rates[t]) * settlement_frequency[t] for s in times]
             cfs[end] += 1
-            
+
             function pv(v_guess)
-                v = interp_function([[0.];maturities[1:t]], vcat(1., discount_vec[1:t - 1], v_guess...))
+                v = interp_function([[0.0]; maturities[1:t]], vcat(1.0, discount_vec[1:t-1], v_guess...))
                 return sum(v.(times) .* cfs)
             end
             target_pv = sum(map(t2 -> discount(Constant(rates[t]), t2), times) .* cfs)
@@ -713,7 +713,7 @@ function bootstrap(rates, maturities, settlement_frequency;interp_function=linea
         end
 
     end
-    return linear_interp([[0.];maturities], [[1.];discount_vec])
+    return linear_interp([[0.0]; maturities], [[1.0]; discount_vec])
 end
 
 ## Generic and Fallbacks
@@ -723,27 +723,27 @@ end
 
 The discount factor for the `rate` for times `from` through `to`. If rate is a `Real` number, will assume a `Constant` interest rate.
 """
-discount(yc,time) = yc.discount(time)
-discount(rate::Rate{<:Real,<:CompoundingFrequency},from,to) = discount(Constant(rate), from, to)
-discount(rate::Rate{<:Real,<:CompoundingFrequency},to) = discount(Constant(rate), to)
+discount(yc, time) = yc.discount(time)
+discount(rate::Rate{<:Real,<:CompoundingFrequency}, from, to) = discount(Constant(rate), from, to)
+discount(rate::Rate{<:Real,<:CompoundingFrequency}, to) = discount(Constant(rate), to)
 
 
 
-discount(yc,from,to) = discount(yc, to) / discount(yc, from)
+discount(yc, from, to) = discount(yc, to) / discount(yc, from)
 
 """
     forward(curve,from,to,CompoundingFrequency=Periodic(1))
 
 The forward `Rate` implied by the curve between times `from` and `to`.
 """
-    function forward(yc, from, to)
-    return forward(yc,from,to,Periodic(1))
+function forward(yc, from, to)
+    return forward(yc, from, to, Periodic(1))
 end
 
-function forward(yc,from,to,cf::T) where {T<:CompoundingFrequency}
+function forward(yc, from, to, cf::T) where {T<:CompoundingFrequency}
 
-    r  = Periodic((accumulation(yc, to) / accumulation(yc, from))^(1 / (to - from)) - 1,1)
-    return convert(cf,r)
+    r = Periodic((accumulation(yc, to) / accumulation(yc, from))^(1 / (to - from)) - 1, 1)
+    return convert(cf, r)
 end
 
 function forward(yc, from)
@@ -756,15 +756,15 @@ end
 
 The accumulation factor for the `rate` for times `from` through `to`. If rate is a `Real` number, will assume a `Constant` interest rate.
 """
-function accumulation(y::T, time) where {T <: AbstractYield}
+function accumulation(y::T, time) where {T<:AbstractYield}
     return 1 ./ discount(y, time)
 end
-accumulation(rate::Rate{<:Real,<:CompoundingFrequency},to) = accumulation(Constant(rate), to)
+accumulation(rate::Rate{<:Real,<:CompoundingFrequency}, to) = accumulation(Constant(rate), to)
 
-function accumulation(y::T, from, to) where {T <: AbstractYield}
+function accumulation(y::T, from, to) where {T<:AbstractYield}
     return 1 ./ discount(y, from, to)
 end
-accumulation(rate::Rate{<:Real,<:CompoundingFrequency},from,to) = accumulation(Constant(rate), from, to)
+accumulation(rate::Rate{<:Real,<:CompoundingFrequency}, from, to) = accumulation(Constant(rate), from, to)
 
 ## Curve Manipulations
 struct RateCombination <: AbstractYield
@@ -773,9 +773,9 @@ struct RateCombination <: AbstractYield
     op
 end
 
-rate(rc::RateCombination,time) = rc.op(rate(rc.r1, time), rate(rc.r2, time))
-function discount(rc::RateCombination, time) 
-    a1 = discount(rc.r1, time)^(-1 / time) - 1  
+rate(rc::RateCombination, time) = rc.op(rate(rc.r1, time), rate(rc.r2, time))
+function discount(rc::RateCombination, time)
+    a1 = discount(rc.r1, time)^(-1 / time) - 1
     a2 = discount(rc.r2, time)^(-1 / time) - 1
     return 1 / (1 + rc.op(a1, a2))^time
 end
@@ -786,7 +786,7 @@ end
 The addition of two yields will create a `RateCombination`. For `rate`, `discount`, and `accumulation` purposes the spot rates of the two curves will be added together.
 """
 function Base.:+(a::AbstractYield, b::AbstractYield)
-    return RateCombination(a, b, +) 
+    return RateCombination(a, b, +)
 end
 
 function Base.:+(a::Constant, b::Constant)
@@ -796,15 +796,15 @@ function Base.:+(a::Constant, b::Constant)
         Rate(
             rate(a.rate) + rate_new_basis,
             a_kind
-            )
         )
+    )
 end
 
-function Base.:+(a::T, b) where {T <: AbstractYield}
+function Base.:+(a::T, b) where {T<:AbstractYield}
     return a + Constant(b)
 end
 
-function Base.:+(a, b::T) where {T <: AbstractYield}
+function Base.:+(a, b::T) where {T<:AbstractYield}
     return Constant(a) + b
 end
 
@@ -814,7 +814,7 @@ end
 The subtraction of two yields will create a `RateCombination`. For `rate`, `discount`, and `accumulation` purposes the spot rates of the second curves will be subtracted from the first.
 """
 function Base.:-(a::AbstractYield, b::AbstractYield)
-    return RateCombination(a, b, -) 
+    return RateCombination(a, b, -)
 end
 
 function Base.:-(a::Constant, b::Constant)
@@ -824,22 +824,22 @@ function Base.:-(a::Constant, b::Constant)
         Rate(
             rate(a.rate) - rate_new_basis,
             a_kind
-            )
         )
+    )
 end
 
-function Base.:-(a::T, b) where {T <: AbstractYield}
+function Base.:-(a::T, b) where {T<:AbstractYield}
     return a - Constant(b)
 end
 
-function Base.:-(a, b::T) where {T <: AbstractYield}
+function Base.:-(a, b::T) where {T<:AbstractYield}
     return Constant(a) - b
 end
 
-linear_interp(xs,ys) = Interpolations.extrapolate(
-    Interpolations.interpolate((xs,), ys, Interpolations.Gridded(Interpolations.Linear())), 
+linear_interp(xs, ys) = Interpolations.extrapolate(
+    Interpolations.interpolate((xs,), ys, Interpolations.Gridded(Interpolations.Linear())),
     Interpolations.Line()
-    ) 
+)
 
 end
 

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -165,6 +165,19 @@ function rate(r::Rate{<:Real,<:CompoundingFrequency})
     r.value
 end
 
+function Base.isapprox(a::Rate{N,T},b::Rate{N,T};atol::Real=0, rtol::Real=atol>0 ? 0 : √eps()) where {T<:Periodic,N<:Real}
+    return (a.compounding.frequency == b.compounding.frequency) && isapprox(rate(a), rate(b);atol,rtol)
+end
+
+function Base.isapprox(a::Rate{N,T},b::Rate{N,T};atol::Real=0, rtol::Real=atol>0 ? 0 : √eps()) where {T<:Continuous,N<:Real}
+    return isapprox(rate(a), rate(b);atol,rtol)
+end
+
+# the fallback for rates not of the same type
+function Base.isapprox(a::T,b::N;atol::Real=0, rtol::Real=atol>0 ? 0 : √eps()) where {T<:Rate,N<:Rate}
+    return isapprox(convert(b.compounding,a),b;atol,rtol)
+end
+
 """
 An AbstractYield is an object which can be used as an argument to:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,35 +2,35 @@ using Yields
 using Test
 
 @testset "Yields.jl" begin
-    
+
     @testset "rate types" begin
-        rs = Rate.([0.1,.02], Yields.Continuous())
+        rs = Rate.([0.1, 0.02], Yields.Continuous())
         @test rs[1] == Rate(0.1, Yields.Continuous())
         @test rate(rs[1]) == 0.1
     end
-    
+
     @testset "constructor" begin
         @test Yields.Continuous(0.05) == Rate(0.05, Yields.Continuous())
         @test Yields.Periodic(0.02, 2) == Rate(0.02, Yields.Periodic(2))
         @test Rate(0.02, 2) == Rate(0.02, Yields.Periodic(2))
         @test Rate(0.02, Inf) == Rate(0.02, Yields.Continuous())
     end
-    
+
     @testset "rate conversions" begin
-        m = Rate(.1, Yields.Periodic(2))
+        m = Rate(0.1, Yields.Periodic(2))
         @test rate(convert(Yields.Continuous(), m)) ≈ rate(Rate(0.09758, Yields.Continuous())) atol = 1e-5
         c = Rate(0.09758, Yields.Continuous())
         @test convert(Yields.Continuous(), c) == c
         @test rate(convert(Yields.Periodic(2), c)) ≈ rate(Rate(0.1, Yields.Periodic(2))) atol = 1e-5
         @test rate(convert(Yields.Periodic(4), m)) ≈ rate(Rate(0.09878030638383972, Yields.Periodic(4))) atol = 1e-5
-        
+
     end
 
     @testset "rate equality" begin
-        a = Yields.Periodic(.02,2)
-        b = Yields.Periodic(.03,2)
-        c = Yields.Continuous(.02)
-    
+        a = Yields.Periodic(0.02, 2)
+        b = Yields.Periodic(0.03, 2)
+        c = Yields.Continuous(0.02)
+
         @test a == a
         @test a != b
         @test ~(a ≈ b)
@@ -42,31 +42,31 @@ using Test
     @testset "constant curve and rate -> Constant" begin
         yield = Yields.Constant(0.05)
         rate = Yields.Rate(0.05, Yields.Periodic(1))
-        
-        @testset "constant discount time: $time" for time in [0,0.5,1,10]
-            @test discount(yield, time) ≈ 1 / (1.05)^time 
-            @test discount(rate, time) ≈ 1 / (1.05)^time 
-            @test discount(rate, 0, time) ≈ 1 / (1.05)^time 
+
+        @testset "constant discount time: $time" for time in [0, 0.5, 1, 10]
+            @test discount(yield, time) ≈ 1 / (1.05)^time
+            @test discount(rate, time) ≈ 1 / (1.05)^time
+            @test discount(rate, 0, time) ≈ 1 / (1.05)^time
         end
-        @testset "constant discount scalar time: $time" for time in [0,0.5,1,10]
-            @test discount(0.05, time) ≈ 1 / (1.05)^time 
+        @testset "constant discount scalar time: $time" for time in [0, 0.5, 1, 10]
+            @test discount(0.05, time) ≈ 1 / (1.05)^time
         end
 
-        @testset "constant accumulation scalar time: $time" for time in [0,0.5,1,10]
-            @test accumulation(0.05, time) ≈ 1 * (1.05)^time 
+        @testset "constant accumulation scalar time: $time" for time in [0, 0.5, 1, 10]
+            @test accumulation(0.05, time) ≈ 1 * (1.05)^time
         end
 
         @testset "broadcasting" begin
-            @test all(discount.(yield, [1,2,3]) .== 1 ./ 1.05.^(1:3))
-            @test all(accumulation.(yield, [1,2,3]) .==  1.05.^(1:3))
+            @test all(discount.(yield, [1, 2, 3]) .== 1 ./ 1.05 .^ (1:3))
+            @test all(accumulation.(yield, [1, 2, 3]) .== 1.05 .^ (1:3))
         end
 
-        @testset "constant accumulation time: $time" for time in [0,0.5,1,10]
+        @testset "constant accumulation time: $time" for time in [0, 0.5, 1, 10]
             @test accumulation(yield, time) ≈ 1 * 1.05^time
             @test accumulation(rate, time) ≈ 1 * 1.05^time
             @test accumulation(rate, 0, time) ≈ 1 * 1.05^time
         end
-        
+
         @testset "CompoundingFrequency" begin
             @testset "Continuous" begin
                 cnst = Yields.Constant(Yields.Continuous(0.05))
@@ -74,142 +74,142 @@ using Test
                 @test accumulation(cnst, 2) == exp(0.05 * 2)
                 @test discount(cnst, 2) == 1 / exp(0.05 * 2)
             end
-            
+
             @testset "Periodic" begin
                 p = Yields.Constant(Rate(0.05, Yields.Periodic(2)))
                 @test accumulation(p, 1) == (1 + 0.05 / 2)^(1 * 2)
                 @test accumulation(p, 2) == (1 + 0.05 / 2)^(2 * 2)
                 @test discount(p, 2) == 1 / (1 + 0.05 / 2)^(2 * 2)
-                
+
             end
         end
-        
-        
+
+
         yield_2x = yield + yield
         yield_add = yield + 0.05
         add_yield = 0.05 + yield
-        @testset "constant discount added" for time in [0,0.5,1,10]
-            @test discount(yield_2x, time) ≈ 1 / (1.1)^time 
-            @test discount(yield_add, time) ≈ 1 / (1.1)^time 
-            @test discount(add_yield, time) ≈ 1 / (1.1)^time 
+        @testset "constant discount added" for time in [0, 0.5, 1, 10]
+            @test discount(yield_2x, time) ≈ 1 / (1.1)^time
+            @test discount(yield_add, time) ≈ 1 / (1.1)^time
+            @test discount(add_yield, time) ≈ 1 / (1.1)^time
         end
-        
+
         yield_1bps = yield - Yields.Constant(0.04)
         yield_minus = yield - 0.01
         minus_yield = 0.05 - Yields.Constant(0.01)
-        @testset "constant discount subtraction" for time in [0,0.5,1,10]
-            @test discount(yield_1bps, time) ≈ 1 / (1.01)^time 
-            @test discount(yield_minus, time) ≈ 1 / (1.04)^time 
-            @test discount(minus_yield, time) ≈ 1 / (1.04)^time 
+        @testset "constant discount subtraction" for time in [0, 0.5, 1, 10]
+            @test discount(yield_1bps, time) ≈ 1 / (1.01)^time
+            @test discount(yield_minus, time) ≈ 1 / (1.04)^time
+            @test discount(minus_yield, time) ≈ 1 / (1.04)^time
         end
     end
-            
+
     @testset "short curve" begin
-        z = Yields.Zero([0.0,0.05], [1,2])
+        z = Yields.Zero([0.0, 0.05], [1, 2])
         @test rate(zero(z, 1)) ≈ 0.00
         @test discount(z, 1) ≈ 1.00
         @test rate(zero(z, 2)) ≈ 0.05
 
         # test no times constructor
-        z = Yields.Zero([0.0,0.05])
+        z = Yields.Zero([0.0, 0.05])
         @test rate(zero(z, 1)) ≈ 0.00
         @test discount(z, 1) ≈ 1.00
         @test rate(zero(z, 2)) ≈ 0.05
     end
-    
+
     @testset "Step curve" begin
-        y = Yields.Step([0.02,0.05], [1,2])
-        
+        y = Yields.Step([0.02, 0.05], [1, 2])
+
         @test rate(y, 0.5) == 0.02
-        
+
         @test discount(y, 0.0) ≈ 1
         @test discount(y, 0.5) ≈ 1 / (1.02)^(0.5)
         @test discount(y, 1) ≈ 1 / (1.02)^(1)
         @test rate(y, 1) ≈ 0.02
-        
+
         @test discount(y, 2) ≈ 1 / (1.02) / 1.05
         @test rate(y, 2) ≈ 0.05
         @test rate(y, 2.5) ≈ 0.05
-        
+
         @test discount(y, 2) ≈ 1 / (1.02) / 1.05
-        
+
         @test discount(y, 1.5) ≈ 1 / (1.02) / 1.05^(0.5)
-        
+
         @testset "broadcasting" begin
-            @test all(discount.(y, [1,2]) .== [1 / 1.02,1 / 1.02 / 1.05])
-            @test all(accumulation.(y, [1,2]) .== [1.02,1.02 * 1.05])
+            @test all(discount.(y, [1, 2]) .== [1 / 1.02, 1 / 1.02 / 1.05])
+            @test all(accumulation.(y, [1, 2]) .== [1.02, 1.02 * 1.05])
         end
-        
-        y = Yields.Step([0.02,0.07])
+
+        y = Yields.Step([0.02, 0.07])
         @test rate(y, 0.5) ≈ 0.02
         @test rate(y, 1) ≈ 0.02
         @test rate(y, 1.5) ≈ 0.07
 
     end
-    
+
     @testset "Salomon Understanding the Yield Curve Pt 1 Figure 9" begin
         maturity = collect(1:10)
-        
-        par = [6.,8.,9.5,10.5,11.0,11.25,11.38,11.44,11.48,11.5] ./ 100
-        spot = [6.,8.08,9.72,10.86,11.44,11.71,11.83,11.88,11.89,11.89] ./ 100
-        
+
+        par = [6.0, 8.0, 9.5, 10.5, 11.0, 11.25, 11.38, 11.44, 11.48, 11.5] ./ 100
+        spot = [6.0, 8.08, 9.72, 10.86, 11.44, 11.71, 11.83, 11.88, 11.89, 11.89] ./ 100
+
         # the forwards for 7+ have been adjusted from the table - perhaps rounding issues are exacerbated 
         # in the text? forwards for <= 6 matched so reasonably confident that the algo is correct
         # fwd = [6.,10.2,13.07,14.36,13.77,13.1,12.55,12.2,11.97,11.93] ./ 100 # from text
-        fwd = [6.,10.2,13.07,14.36,13.77,13.1,12.61,12.14,12.05,11.84] ./ 100  # modified
-        
+        fwd = [6.0, 10.2, 13.07, 14.36, 13.77, 13.1, 12.61, 12.14, 12.05, 11.84] ./ 100  # modified
+
         y = Yields.Par(Rate.(par, Yields.Periodic(1)), maturity)
-        
+
         @testset "UTYC Figure 9 par -> spot : $mat" for mat in maturity
             @test rate(zero(y, mat)) ≈ spot[mat] atol = 0.0001
-            @test forward(y, mat - 1) ≈ Yields.Periodic(fwd[mat],1) atol = 0.0001
+            @test forward(y, mat - 1) ≈ Yields.Periodic(fwd[mat], 1) atol = 0.0001
         end
-        
+
     end
-    
-    @testset "simple rate and forward" begin 
+
+    @testset "simple rate and forward" begin
         # Risk Managment and Financial Institutions, 5th ed. Appendix B
-        
+
         maturity = [0.5, 1.0, 1.5, 2.0]
-        zero    = [5.0, 5.8, 6.4, 6.8] ./ 100
+        zero = [5.0, 5.8, 6.4, 6.8] ./ 100
         curve = Yields.Zero(zero, maturity)
-        
+
         @test discount(curve, 0) ≈ 1
         @test discount(curve, 1) ≈ 1 / (1 + zero[2])
         @test discount(curve, 2) ≈ 1 / (1 + zero[4])^2
-        
-        @test forward(curve, 0.5, 1.0) ≈ Yields.Periodic(6.6 / 100,1) atol = 0.001
-        @test forward(curve, 1.0, 1.5) ≈ Yields.Periodic(7.6 / 100,1) atol = 0.001
-        @test forward(curve, 1.5, 2.0) ≈ Yields.Periodic(8.0 / 100,1) atol = 0.001
-        
+
+        @test forward(curve, 0.5, 1.0) ≈ Yields.Periodic(6.6 / 100, 1) atol = 0.001
+        @test forward(curve, 1.0, 1.5) ≈ Yields.Periodic(7.6 / 100, 1) atol = 0.001
+        @test forward(curve, 1.5, 2.0) ≈ Yields.Periodic(8.0 / 100, 1) atol = 0.001
+
         y = Yields.Zero(zero)
-        
+
         @test discount(y, 1) ≈ 1 / 1.05
         @test discount(y, 2) ≈ 1 / 1.058^2
 
         @testset "broadcasting" begin
-            @test all(discount.(y, [1,2]) .== [1 / 1.05,1 / 1.058^2])
-            @test all(accumulation.(y, [1,2]) .== [1.05, 1.058^2])
+            @test all(discount.(y, [1, 2]) .== [1 / 1.05, 1 / 1.058^2])
+            @test all(accumulation.(y, [1, 2]) .== [1.05, 1.058^2])
         end
-        
-    end
-    
-    @testset "Forward Rates" begin 
-        # Risk Managment and Financial Institutions, 5th ed. Appendix B
-        
-        forwards = [0.05, 0.04, 0.03, 0.08]
-        curve = Yields.Forward(forwards, [1,2,3,4])
 
-        
+    end
+
+    @testset "Forward Rates" begin
+        # Risk Managment and Financial Institutions, 5th ed. Appendix B
+
+        forwards = [0.05, 0.04, 0.03, 0.08]
+        curve = Yields.Forward(forwards, [1, 2, 3, 4])
+
+
         @testset "discounts: $t" for (t, r) in enumerate(forwards)
-            @test discount(curve, t) ≈ reduce((v, r) -> v / (1 + r), forwards[1:t]; init=1.0)
+            @test discount(curve, t) ≈ reduce((v, r) -> v / (1 + r), forwards[1:t]; init = 1.0)
         end
-        
+
         # test constructor without times
         curve = Yields.Forward(forwards)
-        
+
         @testset "discounts: $t" for (t, r) in enumerate(forwards)
-            @test discount(curve, t) ≈ reduce((v, r) -> v / (1 + r), forwards[1:t]; init=1.0)
+            @test discount(curve, t) ≈ reduce((v, r) -> v / (1 + r), forwards[1:t]; init = 1.0)
         end
 
         @test accumulation(curve, 0, 1) ≈ 1.05
@@ -217,49 +217,49 @@ using Test
         @test accumulation(curve, 0, 2) ≈ 1.04 * 1.05
 
         @testset "broadcasting" begin
-            @test all(accumulation.(curve, [1,2]) .≈ [1.05,1.04 * 1.05])
-            @test all(discount.(curve, [1,2]) .≈ 1 ./ [1.05,1.04 * 1.05])
+            @test all(accumulation.(curve, [1, 2]) .≈ [1.05, 1.04 * 1.05])
+            @test all(discount.(curve, [1, 2]) .≈ 1 ./ [1.05, 1.04 * 1.05])
         end
-        
+
         # addition / subtraction
         @test discount(curve + 0.1, 1) ≈ 1 / 1.15
         @test discount(curve - 0.03, 1) ≈ 1 / 1.02
-        
-        
-        
+
+
+
         @testset "with specified timepoints" begin
-            i = [0.0,0.05]
-            times = [0.5,1.5]
+            i = [0.0, 0.05]
+            times = [0.5, 1.5]
             y = Yields.Forward(i, times)
-            @test discount(y, 0.5) ≈ 1 / 1.0^0.5  
+            @test discount(y, 0.5) ≈ 1 / 1.0^0.5
             @test discount(y, 1.5) ≈ 1 / 1.0^0.5 / 1.05^1
-            
+
         end
-        
+
     end
-    
+
     @testset "base + spread" begin
         riskfree_maturities = [0.5, 1.0, 1.5, 2.0]
-        riskfree    = [5.0, 5.8, 6.4, 6.8] ./ 100 # spot rates
-        
+        riskfree = [5.0, 5.8, 6.4, 6.8] ./ 100 # spot rates
+
         spread_maturities = [0.5, 1.0, 1.5, 3.0] # different maturities
-        spread    = [1.0, 1.8, 1.4, 1.8] ./ 100 # spot spreads
-        
+        spread = [1.0, 1.8, 1.4, 1.8] ./ 100 # spot spreads
+
         rf_curve = Yields.Zero(riskfree, riskfree_maturities)
         spread_curve = Yields.Zero(spread, spread_maturities)
-        
-        yield = rf_curve + spread_curve 
-        
+
+        yield = rf_curve + spread_curve
+
         @test discount(yield, 1.0) ≈ 1 / (1 + riskfree[2] + spread[2])^1
         @test discount(yield, 1.5) ≈ 1 / (1 + riskfree[3] + spread[3])^1.5
     end
-    
+
     @testset "actual cmt treasury" begin
         # Fabozzi 5-5,5-6
-        cmt  = [5.25,5.5,5.75,6.0,6.25,6.5,6.75,6.8,7.0,7.1,7.15,7.2,7.3,7.35,7.4,7.5,7.6,7.6,7.7,7.8] ./ 100
-        mats = collect(0.5:0.5:10.)
+        cmt = [5.25, 5.5, 5.75, 6.0, 6.25, 6.5, 6.75, 6.8, 7.0, 7.1, 7.15, 7.2, 7.3, 7.35, 7.4, 7.5, 7.6, 7.6, 7.7, 7.8] ./ 100
+        mats = collect(0.5:0.5:10.0)
         curve = Yields.CMT(cmt, mats)
-        targets = [5.25,5.5,5.76,6.02,6.28,6.55,6.82,6.87,7.09,7.2,7.26,7.31,7.43,7.48,7.54,7.67,7.8,7.79,7.93,8.07] ./ 100
+        targets = [5.25, 5.5, 5.76, 6.02, 6.28, 6.55, 6.82, 6.87, 7.09, 7.2, 7.26, 7.31, 7.43, 7.48, 7.54, 7.67, 7.8, 7.79, 7.93, 8.07] ./ 100
         target_periodicity = fill(2, length(mats))
         target_periodicity[2] = 1 # 1 year is a no-coupon, BEY yield, the rest are semiannual BEY
         @testset "Fabozzi bootstrapped rates" for (r, mat, target, tp) in zip(cmt, mats, targets, target_periodicity)
@@ -267,150 +267,150 @@ using Test
         end
 
         # Hull, problem 4.34
-        adj = ((1 + .051813 / 2)^2 - 1) * 100
-        cmt  = [4.0816,adj,5.4986,5.8620] ./ 100
-        mats =  [.5,1.,1.5,2.]
+        adj = ((1 + 0.051813 / 2)^2 - 1) * 100
+        cmt = [4.0816, adj, 5.4986, 5.8620] ./ 100
+        mats = [0.5, 1.0, 1.5, 2.0]
         curve = Yields.CMT(cmt, mats)
-        targets = [4.0405,5.1293,5.4429,5.8085] ./ 100
+        targets = [4.0405, 5.1293, 5.4429, 5.8085] ./ 100
         @testset "Hull bootstrapped rates" for (r, mat, target) in zip(cmt, mats, targets)
             @test rate(zero(curve, mat, Yields.Continuous())) ≈ target atol = 0.001
         end
-        
-    #     # https://www.federalreserve.gov/pubs/feds/2006/200628/200628abs.html
-    #     # 2020-04-02 data
-    #     cmt = [0.0945,0.2053,0.4431,0.7139,0.9724,1.2002,1.3925,1.5512,1.6805,1.7853,1.8704,1.9399,1.9972,2.045,2.0855,2.1203,2.1509,2.1783,2.2031,2.2261,2.2477,2.2683,2.2881,2.3074,2.3262,2.3447,2.3629,2.3809,2.3987,2.4164] ./ 100
-    #     mats = collect(1:30)
-    #     curve = Yields.USCMT(cmt,mats)
-    #     target = [0.0945,0.2053,0.444,0.7172,0.9802,1.2142,1.4137,1.5797,1.7161,1.8275,1.9183,1.9928,2.0543,2.1056,2.1492,2.1868,2.2198,2.2495,2.2767,2.302,2.3261,2.3494,2.372,2.3944,2.4167,2.439,2.4614,2.4839,2.5067,2.5297] ./ 100
-        
-    #     @testset "FRB data" for (t,mat,target) in zip(1:length(mats),mats,target)
-    #         @show mat
-    #         if mat >= 1
-    #             @test rate(zero(curve,mat, Yields.Continuous())) ≈ target[mat] atol=0.001
-    #         end
-    #     end
+
+        #     # https://www.federalreserve.gov/pubs/feds/2006/200628/200628abs.html
+        #     # 2020-04-02 data
+        #     cmt = [0.0945,0.2053,0.4431,0.7139,0.9724,1.2002,1.3925,1.5512,1.6805,1.7853,1.8704,1.9399,1.9972,2.045,2.0855,2.1203,2.1509,2.1783,2.2031,2.2261,2.2477,2.2683,2.2881,2.3074,2.3262,2.3447,2.3629,2.3809,2.3987,2.4164] ./ 100
+        #     mats = collect(1:30)
+        #     curve = Yields.USCMT(cmt,mats)
+        #     target = [0.0945,0.2053,0.444,0.7172,0.9802,1.2142,1.4137,1.5797,1.7161,1.8275,1.9183,1.9928,2.0543,2.1056,2.1492,2.1868,2.2198,2.2495,2.2767,2.302,2.3261,2.3494,2.372,2.3944,2.4167,2.439,2.4614,2.4839,2.5067,2.5297] ./ 100
+
+        #     @testset "FRB data" for (t,mat,target) in zip(1:length(mats),mats,target)
+        #         @show mat
+        #         if mat >= 1
+        #             @test rate(zero(curve,mat, Yields.Continuous())) ≈ target[mat] atol=0.001
+        #         end
+        #     end
     end
-    
+
     @testset "OIS" begin
-        ois =  [1.8 , 2.0, 2.2, 2.5, 3.0, 4.0] ./ 100
-        mats = [1 / 12, 1 / 4, 1 / 2,    1,  2,   5]
+        ois = [1.8, 2.0, 2.2, 2.5, 3.0, 4.0] ./ 100
+        mats = [1 / 12, 1 / 4, 1 / 2, 1, 2, 5]
         curve = Yields.OIS(ois, mats)
-        targets = [0.017987,0.019950,0.021880,0.024693,0.029994,0.040401]
+        targets = [0.017987, 0.019950, 0.021880, 0.024693, 0.029994, 0.040401]
         @testset "bootstrapped rates" for (r, mat, target) in zip(ois, mats, targets)
             @test rate(zero(curve, mat, Yields.Continuous())) ≈ target atol = 0.001
         end
     end
-    
+
     @testset "InstrumentQuotes" begin
-       
+
         maturities = [1.3, 2.7]
         prices = [1.1, 0.8]
         zcq = Yields.ZeroCouponQuote.(prices, maturities)
-        @test isa(first(zcq),Yields.ZeroCouponQuote)
- 
+        @test isa(first(zcq), Yields.ZeroCouponQuote)
+
         @test_throws DimensionMismatch Yields.ZeroCouponQuote.([1.3, 2.4, 0.9], maturities)
- 
+
         rates = [0.4, -0.7]
         swq = Yields.SwapQuote.(rates, maturities, 3)
         @test first(swq).frequency == 3
- 
+
         @test_throws DimensionMismatch Yields.SwapQuote.([1.3, 2.4, 0.9], maturities, 3)
         @test_throws DomainError Yields.SwapQuote.(rates, maturities, 0)
         @test_throws DomainError Yields.SwapQuote.(rates, maturities, -2)
- 
+
         rates = [0.4, -0.7]
-        bbq = Yields.BulletBondQuote.(rates, prices,maturities, 3)
+        bbq = Yields.BulletBondQuote.(rates, prices, maturities, 3)
         @test first(bbq).frequency == 3
         @test first(bbq).yield == first(rates)
-        
- 
+
+
         @test_throws DimensionMismatch Yields.BulletBondQuote.([1.3, 2.4, 0.9], prices, maturities, 3)
         @test_throws DimensionMismatch Yields.BulletBondQuote.(rates, prices, [4.3, 5.6, 4.4, 4.4], 3)
         @test first(Yields.BulletBondQuote.(rates, [5.7], maturities, 3)).price == 5.7
         @test_throws DomainError Yields.BulletBondQuote.(rates, prices, maturities, 0)
         @test_throws DomainError Yields.BulletBondQuote.(rates, prices, maturities, -4)
- 
+
     end
- 
+
     @testset "SmithWilson" begin
- 
+
         ufr = 0.03
         α = 0.1
         u = [5.0, 7.0]
         qb = [2.3, -1.2]
- 
+
         # Basic behaviour
-        sw = Yields.SmithWilson(u, qb; ufr=ufr, α=α)
+        sw = Yields.SmithWilson(u, qb; ufr = ufr, α = α)
         @test sw.ufr == ufr
         @test sw.α == α
         @test sw.u == u
         @test sw.qb == qb
-        @test_throws DomainError Yields.SmithWilson(u, [2.4, -3.4, 8.9], ufr=ufr, α=α)
-    
+        @test_throws DomainError Yields.SmithWilson(u, [2.4, -3.4, 8.9], ufr = ufr, α = α)
+
         # Empty u and Qb should result in a flat yield curve
         # Use this to test methods expected from <:AbstractYieldCurve
         # Only discount and zero are explicitly implemented, so the others should follow automatically
-        sw_flat = Yields.SmithWilson(Float64[], Float64[], ufr=ufr, α=α)
+        sw_flat = Yields.SmithWilson(Float64[], Float64[], ufr = ufr, α = α)
         @test discount(sw_flat, 10.0) == exp(-ufr * 10.0)
         @test accumulation(sw_flat, 10.0) ≈ exp(ufr * 10.0)
         @test rate(convert(Yields.Continuous(), zero(sw_flat, 8.0))) ≈ ufr
         @test discount.(sw_flat, [5.0, 10.0]) ≈ exp.(-ufr .* [5.0, 10.0])
         @test rate(convert(Yields.Continuous(), forward(sw_flat, 5.0, 8.0))) ≈ ufr
-    
+
         # A trivial Qb vector (=0) should result in a flat yield curve
-        ufr_curve = Yields.SmithWilson(u, [0.0, 0.0], ufr=ufr, α=α)
+        ufr_curve = Yields.SmithWilson(u, [0.0, 0.0], ufr = ufr, α = α)
         @test discount(ufr_curve, 10.0) == exp(-ufr * 10.0)
-    
+
         # A single payment at time 4, zero interest
-        curve_with_zero_yield = Yields.SmithWilson([4.0], reshape([1.0], 1, 1), [1.0], ufr=ufr, α=α)
+        curve_with_zero_yield = Yields.SmithWilson([4.0], reshape([1.0], 1, 1), [1.0], ufr = ufr, α = α)
         @test discount(curve_with_zero_yield, 4.0) == 1.0
-    
+
         # In the long end it's still just UFR
         @test rate(convert(Yields.Continuous(), forward(curve_with_zero_yield, 1000.0, 2000.0))) ≈ ufr
-    
+
         # Three maturities have known discount factors
         times = [1.0, 2.5, 5.6]
         prices = [0.9, 0.7, 0.5]
         cfs = [1 0 0
-                0 1 0
-                0 0 1]
-    
-        curve_three = Yields.SmithWilson(times, cfs, prices, ufr=ufr, α=α)
+            0 1 0
+            0 0 1]
+
+        curve_three = Yields.SmithWilson(times, cfs, prices, ufr = ufr, α = α)
         @test transpose(cfs) * discount.(curve_three, times) ≈ prices
-    
+
         # Two cash flows with payments at three times
         prices = [1.0, 0.9]
         cfs = [0.1 0.1
-                1.0 0.1
-                0.0 1.0]
-        curve_nondiag = Yields.SmithWilson(times, cfs, prices, ufr=ufr, α=α)
+            1.0 0.1
+            0.0 1.0]
+        curve_nondiag = Yields.SmithWilson(times, cfs, prices, ufr = ufr, α = α)
         @test transpose(cfs) * discount.(curve_nondiag, times) ≈ prices
-    
+
         # Round-trip zero coupon quotes
         zcq_times = [1.2, 4.5, 5.6]
         zcq_prices = [1.0, 0.9, 1.2]
         zcq = Yields.ZeroCouponQuote.(zcq_prices, zcq_times)
-        sw_zcq = Yields.SmithWilson(zcq, ufr=ufr, α=α)
-        @testset "ZeroCouponQuotes round-trip" for idx in 1:length(zcq_times)
+        sw_zcq = Yields.SmithWilson(zcq, ufr = ufr, α = α)
+        @testset "ZeroCouponQuotes round-trip" for idx = 1:length(zcq_times)
             @test discount(sw_zcq, zcq_times[idx]) ≈ zcq_prices[idx]
         end
 
         # uneven frequencies
         swq_maturities = [1.2, 2.5, 3.6]
         swq_interests = [-0.02, 0.3, 0.04]
-        frequency = [2,1,2]
+        frequency = [2, 1, 2]
         swq = Yields.SwapQuote.(swq_interests, swq_maturities, frequency)
         swq_times = 0.5:0.5:3.5   # Maturities are rounded down to multiples of 1/frequency, [1.0, 2.5, 3.5]
         swq_payments = [
-           -0.01  0.3     0.02
-            0.99  0     0.02
-            0     0.3   0.02
-            0     0     0.02
-            0     1.3   0.02
-            0     0     0.02
-            0     0     1.02
+            -0.01 0.3 0.02
+            0.99 0 0.02
+            0 0.3 0.02
+            0 0 0.02
+            0 1.3 0.02
+            0 0 0.02
+            0 0 1.02
         ]
-    
+
         # Round-trip swap quotes
         swq_maturities = [1.2, 2.5, 3.6]
         swq_interests = [-0.02, 0.3, 0.04]
@@ -418,62 +418,62 @@ using Test
         swq = Yields.SwapQuote.(swq_interests, swq_maturities, frequency)
         swq_times = 0.5:0.5:3.5   # Maturities are rounded down to multiples of 1/frequency, [1.0, 2.5, 3.5]
         swq_payments = [-0.01 0.15 0.02
-                        0.99 0.15 0.02
-                        0.0  0.15 0.02
-                        0.0  0.15 0.02
-                        0.0  1.15 0.02
-                        0.0  0.0  0.02
-                        0.0  0.0  1.02]
-        sw_swq = Yields.SmithWilson(swq, ufr=ufr, α=α)
-        @testset "SwapQuotes round-trip" for swapIdx in 1:length(swq_interests)
+            0.99 0.15 0.02
+            0.0 0.15 0.02
+            0.0 0.15 0.02
+            0.0 1.15 0.02
+            0.0 0.0 0.02
+            0.0 0.0 1.02]
+        sw_swq = Yields.SmithWilson(swq, ufr = ufr, α = α)
+        @testset "SwapQuotes round-trip" for swapIdx = 1:length(swq_interests)
             @test sum(discount.(sw_swq, swq_times) .* swq_payments[:, swapIdx]) ≈ 1.0
         end
-    
+
         # Round-trip bullet bond quotes (reuse data from swap quotes)
         bbq_prices = [1.3, 0.1, 4.5]
         bbq = Yields.BulletBondQuote.(swq_interests, bbq_prices, swq_maturities, frequency)
-        sw_bbq = Yields.SmithWilson(bbq, ufr=ufr, α=α)
-        @testset "BulletBondQuotes round-trip" for bondIdx in 1:length(swq_interests)
+        sw_bbq = Yields.SmithWilson(bbq, ufr = ufr, α = α)
+        @testset "BulletBondQuotes round-trip" for bondIdx = 1:length(swq_interests)
             @test sum(discount.(sw_bbq, swq_times) .* swq_payments[:, bondIdx]) ≈ bbq_prices[bondIdx]
         end
-    
+
         # EIOPA risk free rate (no VA), 31 August 2021.
         # https://www.eiopa.europa.eu/sites/default/files/risk_free_interest_rate/eiopa_rfr_20210831.zip
-        eiopa_output_qb = [-0.59556534586390800 
-                            -0.07442224713453920 
-                            -0.34193181987682400 
-                            1.54054875814153000 
-                            -2.15552046042343000 
-                            0.73559290752221900 
-                            1.89365225129089000 
-                            -2.75927773116240000 
-                            2.24893737130629000 
-                            -1.51625404117395000 
-                            0.19284859623817400 
-                            1.13410725406271000 
-                            0.00153268224642171 
-                            0.00147942301778158 
-                            -1.85022125156483000 
-                            0.00336230229850928 
-                            0.00324546553910162 
-                            0.00313268874430658 
-                            0.00302383083427276 
-                            1.36047951448615000]
+        eiopa_output_qb = [-0.59556534586390800
+            -0.07442224713453920
+            -0.34193181987682400
+            1.54054875814153000
+            -2.15552046042343000
+            0.73559290752221900
+            1.89365225129089000
+            -2.75927773116240000
+            2.24893737130629000
+            -1.51625404117395000
+            0.19284859623817400
+            1.13410725406271000
+            0.00153268224642171
+            0.00147942301778158
+            -1.85022125156483000
+            0.00336230229850928
+            0.00324546553910162
+            0.00313268874430658
+            0.00302383083427276
+            1.36047951448615000]
         eiopa_output_u = 1:20
         eiopa_ufr = log(1.036)
         eiopa_α = 0.133394
-        sw_eiopa_expected = Yields.SmithWilson(eiopa_output_u, eiopa_output_qb; ufr=eiopa_ufr, α=eiopa_α)
-    
+        sw_eiopa_expected = Yields.SmithWilson(eiopa_output_u, eiopa_output_qb; ufr = eiopa_ufr, α = eiopa_α)
+
         eiopa_eurswap_maturities = [1:12; 15; 20]
-        eiopa_eurswap_rates = [-0.00615, -0.00575, -0.00535, -0.00485, -0.00425, -0.00375, -0.003145, 
-        -0.00245, -0.00185, -0.00125, -0.000711, -0.00019, 0.00111, 0.00215]   # Reverse engineered from output curve. This is the full precision of market quotes.
+        eiopa_eurswap_rates = [-0.00615, -0.00575, -0.00535, -0.00485, -0.00425, -0.00375, -0.003145,
+            -0.00245, -0.00185, -0.00125, -0.000711, -0.00019, 0.00111, 0.00215]   # Reverse engineered from output curve. This is the full precision of market quotes.
         eiopa_eurswap_quotes = Yields.SwapQuote.(eiopa_eurswap_rates, eiopa_eurswap_maturities, 1)
-        sw_eiopa_actual = Yields.SmithWilson(eiopa_eurswap_quotes, ufr=eiopa_ufr, α=eiopa_α)
-    
+        sw_eiopa_actual = Yields.SmithWilson(eiopa_eurswap_quotes, ufr = eiopa_ufr, α = eiopa_α)
+
         @testset "Match EIOPA calculation" begin
             @test sw_eiopa_expected.u ≈ sw_eiopa_actual.u
             @test sw_eiopa_expected.qb ≈ sw_eiopa_actual.qb
         end
     end
- 
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,19 @@ using Test
         
     end
     
+    @testset "rate equality" begin
+        a = Yields.Periodic(.02,2)
+        b = Yields.Periodic(.03,2)
+        c = Yields.Continuous(.02)
+    
+        @test a == a
+        @test a != b
+        @test ~(a ≈ b)
+        @test ~(a ≈ a)
+        @test ~(a ≈ c)
+
+    end
+
     @testset "constant curve and rate -> Constant" begin
         yield = Yields.Constant(0.05)
         rate = Yields.Rate(0.05, Yields.Periodic(1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ using Test
         @test rate(convert(Yields.Periodic(4), m)) ≈ rate(Rate(0.09878030638383972, Yields.Periodic(4))) atol = 1e-5
         
     end
-    
+
     @testset "rate equality" begin
         a = Yields.Periodic(.02,2)
         b = Yields.Periodic(.03,2)
@@ -162,7 +162,7 @@ using Test
         
         @testset "UTYC Figure 9 par -> spot : $mat" for mat in maturity
             @test rate(zero(y, mat)) ≈ spot[mat] atol = 0.0001
-            @test forward(y, mat - 1) ≈ fwd[mat] atol = 0.0001
+            @test forward(y, mat - 1) ≈ Yields.Periodic(fwd[mat],1) atol = 0.0001
         end
         
     end
@@ -178,9 +178,9 @@ using Test
         @test discount(curve, 1) ≈ 1 / (1 + zero[2])
         @test discount(curve, 2) ≈ 1 / (1 + zero[4])^2
         
-        @test forward(curve, 0.5, 1.0) ≈ 6.6 / 100 atol = 0.001
-        @test forward(curve, 1.0, 1.5) ≈ 7.6 / 100 atol = 0.001
-        @test forward(curve, 1.5, 2.0) ≈ 8.0 / 100 atol = 0.001
+        @test forward(curve, 0.5, 1.0) ≈ Yields.Periodic(6.6 / 100,1) atol = 0.001
+        @test forward(curve, 1.0, 1.5) ≈ Yields.Periodic(7.6 / 100,1) atol = 0.001
+        @test forward(curve, 1.5, 2.0) ≈ Yields.Periodic(8.0 / 100,1) atol = 0.001
         
         y = Yields.Zero(zero)
         
@@ -355,7 +355,7 @@ using Test
         @test accumulation(sw_flat, 10.0) ≈ exp(ufr * 10.0)
         @test rate(convert(Yields.Continuous(), zero(sw_flat, 8.0))) ≈ ufr
         @test discount.(sw_flat, [5.0, 10.0]) ≈ exp.(-ufr .* [5.0, 10.0])
-        @test rate(convert(Yields.Continuous(), Rate(forward(sw_flat, 5.0, 8.0)))) ≈ ufr
+        @test rate(convert(Yields.Continuous(), forward(sw_flat, 5.0, 8.0))) ≈ ufr
     
         # A trivial Qb vector (=0) should result in a flat yield curve
         ufr_curve = Yields.SmithWilson(u, [0.0, 0.0], ufr=ufr, α=α)
@@ -366,7 +366,7 @@ using Test
         @test discount(curve_with_zero_yield, 4.0) == 1.0
     
         # In the long end it's still just UFR
-        @test rate(convert(Yields.Continuous(), Rate(forward(curve_with_zero_yield, 1000.0, 2000.0)))) ≈ ufr
+        @test rate(convert(Yields.Continuous(), forward(curve_with_zero_yield, 1000.0, 2000.0))) ≈ ufr
     
         # Three maturities have known discount factors
         times = [1.0, 2.5, 5.6]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,7 @@ using Test
         @test a == a
         @test a != b
         @test ~(a ≈ b)
-        @test ~(a ≈ a)
+        @test (a ≈ a)
         @test ~(a ≈ c)
 
     end


### PR DESCRIPTION
## single yield curve

### before
```
julia> @benchmark discount($a,0,1)
BenchmarkTools.Trial: 10000 samples with 990 evaluations.
 Range (min … max):  43.561 ns … 694.738 ns  ┊ GC (min … max): 0.00% … 90.00%
 Time  (median):     44.571 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   45.857 ns ±  18.863 ns  ┊ GC (mean ± σ):  1.25% ±  2.86%

  █▃  ▁                                                         
  ██▃▅█▃▄▄▄▄▄▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  43.6 ns         Histogram: frequency by time         59.1 ns <

 Memory estimate: 48 bytes, allocs estimate: 3.
 ```

### after

```
julia> @benchmark discount($a,0,1)
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):  10.343 ns … 37.538 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.468 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.599 ns ±  1.282 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▄ █ █ ▅ ▄  ▁          ▂ ▁                  ▁              ▂
  ▆▁█▁█▁█▁█▁█▁▁█▁▆▁▁▁▅▁▇▁██▁█▁█▁▇▁▇▁▆▁▁▆▁▇▁▇▁█▁█▁▁█▁▇▁▇▁▆▁▆▁▅ █
  10.3 ns      Histogram: log(frequency) by time      11.5 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
 ```

## rate combination

### before

```
julia> @benchmark discount($c,0,1)
BenchmarkTools.Trial: 10000 samples with 206 evaluations.
 Range (min … max):  367.316 ns …   4.043 μs  ┊ GC (min … max): 0.00% … 86.82%
 Time  (median):     379.854 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   390.790 ns ± 140.040 ns  ┊ GC (mean ± σ):  1.47% ±  3.69%

    ▆█▃▁▄▇▃                                                      
  ▂▇███████▇▅▇▇▅▆▄▄▃▃▃▄▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  367 ns           Histogram: frequency by time          465 ns <

 Memory estimate: 400 bytes, allocs estimate: 25.
 ```

### after

```
julia> @benchmark discount($c,0,1)
BenchmarkTools.Trial: 10000 samples with 985 evaluations.
 Range (min … max):  53.976 ns … 90.778 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     54.145 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   54.728 ns ±  2.285 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▅▃▂▁  ▁▃▁ ▂▁                                               ▁
  █████████████▅▆▆▅▆▆▃▄▄▄▁▄▃▅▃▄▄▃▃▃▁▅▅▅▅▄▅▅▄▃▅▄▅▄▃▅▄▄▁▅▅▅▅▅▆▇ █
  54 ns        Histogram: log(frequency) by time        69 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```