### PR TITLE
significantly improve performance via parametrizing core types

### DIFF
--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -198,10 +198,10 @@ abstract type AbstractYield end
 # make interest curve broadcastable so that you can broadcast over multiple`time`s in `interest_rate`
 Base.Broadcast.broadcastable(ic::T) where {T<:AbstractYield} = Ref(ic)
 
-struct YieldCurve <: AbstractYield
-    rates
-    maturities
-    discount # discount function for time
+struct YieldCurve{T,U,V} <: AbstractYield
+    rates::T
+    maturities::U
+    discount::V # discount function for time
 end
 
 """
@@ -767,10 +767,10 @@ end
 accumulation(rate::Rate{<:Real,<:CompoundingFrequency}, from, to) = accumulation(Constant(rate), from, to)
 
 ## Curve Manipulations
-struct RateCombination <: AbstractYield
-    r1
-    r2
-    op
+struct RateCombination{T,U,V} <: AbstractYield
+    r1::T
+    r2::U
+    op::V
 end
 
 rate(rc::RateCombination, time) = rc.op(rate(rc.r1, time), rate(rc.r2, time))


### PR DESCRIPTION
## single yield curve

### before
```
julia> @benchmark discount($a,0,1)
BenchmarkTools.Trial: 10000 samples with 990 evaluations.
 Range (min … max):  43.561 ns … 694.738 ns  ┊ GC (min … max): 0.00% … 90.00%
 Time  (median):     44.571 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   45.857 ns ±  18.863 ns  ┊ GC (mean ± σ):  1.25% ±  2.86%

  █▃  ▁                                                         
  ██▃▅█▃▄▄▄▄▄▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  43.6 ns         Histogram: frequency by time         59.1 ns <

 Memory estimate: 48 bytes, allocs estimate: 3.
 ```

### after

```
julia> @benchmark discount($a,0,1)
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):  10.343 ns … 37.538 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.468 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.599 ns ±  1.282 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▄ █ █ ▅ ▄  ▁          ▂ ▁                  ▁              ▂
  ▆▁█▁█▁█▁█▁█▁▁█▁▆▁▁▁▅▁▇▁██▁█▁█▁▇▁▇▁▆▁▁▆▁▇▁▇▁█▁█▁▁█▁▇▁▇▁▆▁▆▁▅ █
  10.3 ns      Histogram: log(frequency) by time      11.5 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
 ```

## rate combination

### before

```
julia> @benchmark discount($c,0,1)
BenchmarkTools.Trial: 10000 samples with 206 evaluations.
 Range (min … max):  367.316 ns …   4.043 μs  ┊ GC (min … max): 0.00% … 86.82%
 Time  (median):     379.854 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   390.790 ns ± 140.040 ns  ┊ GC (mean ± σ):  1.47% ±  3.69%

    ▆█▃▁▄▇▃                                                      
  ▂▇███████▇▅▇▇▅▆▄▄▃▃▃▄▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  367 ns           Histogram: frequency by time          465 ns <

 Memory estimate: 400 bytes, allocs estimate: 25.
 ```

### after

```
julia> @benchmark discount($c,0,1)
BenchmarkTools.Trial: 10000 samples with 985 evaluations.
 Range (min … max):  53.976 ns … 90.778 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     54.145 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   54.728 ns ±  2.285 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▅▃▂▁  ▁▃▁ ▂▁                                               ▁
  █████████████▅▆▆▅▆▆▃▄▄▄▁▄▃▅▃▄▄▃▃▃▁▅▅▅▅▄▅▅▄▃▅▄▅▄▃▅▄▄▁▅▅▅▅▅▆▇ █
  54 ns        Histogram: log(frequency) by time        69 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```