### PR TITLE
Improve the display of curves

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.8.0"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
 ForwardDiff = "^0.10"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ y1 = Yields.Constant(0.05)
 y2 = y1 + 0.01                # y2 is a yield of 0.06
 ```
 
+### Forward Starting Curves
+
+Constructed curves can be shifted so that a future timepoint becomes the effective time-zero for a said curve.
+
+```julia-repl
+julia> zero = [5.0, 5.8, 6.4, 6.8] ./ 100
+julia> maturity = [0.5, 1.0, 1.5, 2.0]
+julia> curve = Yields.Zero(zero, maturity)
+julia> fwd = Yields.ForwardStarting(curve, 1.0)
+
+julia> discount(curve,1,2)
+0.9275624570410582
+
+julia> discount(fwd,1) # `curve` has effectively been reindexed to `1.0`
+0.9275624570410582
+```
+
 ### Conversion
 
 Convert rates between different types with `convert`. E.g.:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -99,6 +99,23 @@ y1 = Yields.Constant(0.05)
 y2 = y1 + 0.01                # y2 is a yield of 0.06
 ```
 
+### Forward Starting Curves
+
+Constructed curves can be shifted so that a future timepoint becomes the effective time-zero for a said curve.
+
+```julia-repl
+julia> zero = [5.0, 5.8, 6.4, 6.8] ./ 100
+julia> maturity = [0.5, 1.0, 1.5, 2.0]
+julia> curve = Yields.Zero(zero, maturity)
+julia> fwd = Yields.ForwardStarting(curve, 1.0)
+
+julia> discount(curve,1,2)
+0.9275624570410582
+
+julia> discount(fwd,1) # `curve` has effectively been reindexed to `1.0`
+0.9275624570410582
+```
+
 ## Internals
 
 For time-variant yields (ie yield *curves*), the inputs are converted to spot rates and linearly interpolated (using [`Interpolations.jl`](https://github.com/JuliaMath/Interpolations.jl)).

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -204,6 +204,43 @@ struct YieldCurve{T,U,V} <: AbstractYield
     discount::V # discount function for time
 end
 
+# Forward curves
+
+"""
+    ForwardStarting(curve,forwardstart)
+
+Rebase a `curve` so that `discount`/`accumulation`/etc. are re-based so that time zero from the new curves perspective is the given `forwardstart` time.
+
+# Examples
+
+```julia-repl
+julia> zero = [5.0, 5.8, 6.4, 6.8] ./ 100
+julia> maturity = [0.5, 1.0, 1.5, 2.0]
+julia> curve = Yields.Zero(zero, maturity)
+julia> fwd = Yields.ForwardStarting(curve, 1.0)
+
+julia> discount(curve,1,2)
+0.9275624570410582
+
+julia> discount(fwd,1) # `curve` has effectively been reindexed to `1.0`
+0.9275624570410582
+```
+
+# Extended Help
+
+While `ForwardStarting` could be nested so that, e.g. the third period's curve is the one-period forward of the second period's curve, it will be more efficient to reuse the initial curve from a runtime and compiler perspective.
+
+`ForwardStarting` is not used to construct a curve based on forward rates. See  [`Forward`](@ref) instead.
+"""
+struct ForwardStarting{T,U} <: AbstractYield
+    curve::U
+    forwardstart::T
+end
+
+function discount(c::ForwardStarting, to)
+    discount(c.curve, c.forwardstart, to + c.forwardstart)
+end
+
 """
     zero(curve,time)
     zero(curve,time,CompoundingFrequency)
@@ -842,4 +879,3 @@ linear_interp(xs, ys) = Interpolations.extrapolate(
 )
 
 end
-

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -3,6 +3,7 @@ module Yields
 import Interpolations
 import ForwardDiff
 using LinearAlgebra
+using UnicodePlots
 
 # don't export type, as the API of Yields.Zero is nicer and 
 # less polluting than Zero and less/equally verbose as ZeroYieldCurve or ZeroCurve
@@ -881,5 +882,11 @@ linear_interp(xs, ys) = Interpolations.extrapolate(
     Interpolations.interpolate((xs,), ys, Interpolations.Gridded(Interpolations.Linear())),
     Interpolations.Line()
 )
+
+function Base.show(io::IO, curve::T) where {T<:AbstractYield}
+    r = zero(curve, 1)
+    ylabel = isa(r.compounding, Continuous) ? "Continuous" : "Periodic($(r.compounding.frequency))"
+    display(lineplot(t -> rate(zero(curve, t)), 0.01, 5, xlabel = "time", ylabel = ylabel, compact = true, name = "Zero rates"))
+end
 
 end

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -883,10 +883,27 @@ linear_interp(xs, ys) = Interpolations.extrapolate(
     Interpolations.Line()
 )
 
+# used to display simple type name in show method
+# https://stackoverflow.com/questions/70043313/get-simple-name-of-type-in-julia?noredirect=1#comment123823820_70043313
+name(::Type{T}) where {T} = (isempty(T.parameters) ? T : T.name.wrapper)
+
 function Base.show(io::IO, curve::T) where {T<:AbstractYield}
+    println() # blank line for padding
     r = zero(curve, 1)
     ylabel = isa(r.compounding, Continuous) ? "Continuous" : "Periodic($(r.compounding.frequency))"
-    display(lineplot(t -> rate(zero(curve, t)), 0.01, 5, xlabel = "time", ylabel = ylabel, compact = true, name = "Zero rates"))
+    kind = name(typeof(curve))
+    l = lineplot(
+        t -> rate(zero(curve, t)),
+        0.0, #from 
+        30.0,  # to
+        xlabel = "time",
+        ylabel = ylabel,
+        compact = true,
+        name = "Zero rates",
+        width = 60,
+        title = "Yield Curve ($kind)"
+    )
+    display(l)
 end
 
 

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -903,7 +903,7 @@ function Base.show(io::IO, curve::T) where {T<:AbstractYield}
         width = 60,
         title = "Yield Curve ($kind)"
     )
-    display(l)
+    show(io, l)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,6 +238,18 @@ using Test
 
     end
 
+    @testset "forwardcurve" begin
+        maturity = [0.5, 1.0, 1.5, 2.0]
+        zero = [5.0, 5.8, 6.4, 6.8] ./ 100
+        curve = Yields.Zero(zero, maturity)
+
+        fwd = Yields.ForwardStarting(curve, 1.0)
+        @test discount(fwd, 0) ≈ 1
+        @test discount(fwd, 0.5) ≈ discount(curve, 1, 1.5)
+        @test discount(fwd, 1) ≈ discount(curve, 1, 2)
+        @test accumulation(fwd, 1) ≈ accumulation(curve, 1, 2)
+    end
+
     @testset "base + spread" begin
         riskfree_maturities = [0.5, 1.0, 1.5, 2.0]
         riskfree = [5.0, 5.8, 6.4, 6.8] ./ 100 # spot rates
@@ -435,6 +447,13 @@ using Test
         sw_bbq = Yields.SmithWilson(bbq, ufr = ufr, α = α)
         @testset "BulletBondQuotes round-trip" for bondIdx = 1:length(swq_interests)
             @test sum(discount.(sw_bbq, swq_times) .* swq_payments[:, bondIdx]) ≈ bbq_prices[bondIdx]
+        end
+
+        @testset "SW ForwardStarting" begin
+            fwd_time = 1.0
+            fwd = Yields.ForwardStarting(sw_swq, fwd_time)
+
+            @test discount(fwd, 3.7) ≈ discount(sw_swq, fwd_time, fwd_time + 3.7)
         end
 
         # EIOPA risk free rate (no VA), 31 August 2021.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -188,8 +188,8 @@ using Test
         @test discount(y, 2) ≈ 1 / 1.058^2
 
         @testset "broadcasting" begin
-            @test all(discount.(y, [1, 2]) .== [1 / 1.05, 1 / 1.058^2])
-            @test all(accumulation.(y, [1, 2]) .== [1.05, 1.058^2])
+            @test all(discount.(y, [1, 2]) .≈ [1 / 1.05, 1 / 1.058^2])
+            @test all(accumulation.(y, [1, 2]) .≈ [1.05, 1.058^2])
         end
 
     end


### PR DESCRIPTION
With the new parameterized types, the display of `AbstractYields` has gotten very verbose.
Unicode plots is pretty lightweight dependency.

Before:

```julia-repl
julia> zs = [5.0, 5.8, 6.4, 6.8] ./ 100
julia> maturity = [0.5, 1.0, 1.5, 2.0]

julia> curve = Yields.Zero(zs, maturity)
Yields.YieldCurve{Vector{Float64}, Vector{Float64}, Interpolations.Extrapolation{Float64, 1,
Interpolations.GriddedInterpolation{Float64, 1, Float64, Interpolations.Gridded{Interpolations.
Linear{Interpolations.Throw{Interpolations.OnGrid}}}, Tuple{Vector{Float64}}}, Interpolations.
Gridded{Interpolations.Linear{Interpolations.Throw{Interpolations.OnGrid}}}, Interpolations.
Line{Nothing}}}([0.05, 0.057999999999999996, 0.064, 0.068], [0.5, 1.0, 1.5, 2.0], 5-element
extrapolate(interpolate((::Vector{Float64},), ::Vector{Float64}, Gridded(Linear())), Line())
with element type Float64:
 1.0
 0.9759000729485331
 0.9451795841209829
 0.9111451296164018
 0.8767130973923045)
 ```

 After:

![image](https://user-images.githubusercontent.com/711879/142715203-483618c7-46c0-45ab-9280-76d2066a6f95.png)

To consider further:

- [x] How to determine the ending point to display? 

- E.g. the above errors for `30` as endpoint because the discount factor hits zero so far before then and the `zero` hits a negative number and results in a complex result.
- Some curves would have a natural end point of the last defined observation time, but we'd still have to define a fallback time (e.g. a `Constant` curve).

> 30 seems as good as any timepoint for now, can add more specificity or get more dynamic about it as future enhancements

- [x] Show the ylim as (0,max(curve)) but without computing all the points we may not know the limits (plus could go negative)

- [x] Is there a better summary statistic to show than zero rates? Most people won't be familiar with looking at discount or accumulation curves.

> Zero rates seem fine for consistency across different kinds of curves for now. In the future, could try to inpsect the type of rates that were originally used to construct the curve and display them?

- [ ] Is there a way to test?