### PR TITLE
switch underlying interpoliation to use rates instead of discount factor

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -188,8 +188,8 @@ using Test
         @test discount(y, 2) ≈ 1 / 1.058^2
 
         @testset "broadcasting" begin
-            @test all(discount.(y, [1, 2]) .== [1 / 1.05, 1 / 1.058^2])
-            @test all(accumulation.(y, [1, 2]) .== [1.05, 1.058^2])
+            @test all(discount.(y, [1, 2]) .≈ [1 / 1.05, 1 / 1.058^2])
+            @test all(accumulation.(y, [1, 2]) .≈ [1.05, 1.058^2])
         end
 
     end


### PR DESCRIPTION
Extrapolating the discount factor leads to issues outside of the local curve where the discount factor becomes negative, which we don't want to happen.

This changes the results in the extrapolated part of bootstrapped curves to a more correct answer, therefor this is more of a bugfix and user API hasn't changed.

The downside is that instead of precomputing a discount factor, we have to calculate based on intermediate rate so it's a little bit slower. Here, the correctness is worth the tradeoff.

Before:
```
julia> zero = [5.0, 5.8, 6.4, 6.8] ./ 100
4-element Vector{Float64}:
 0.05
 0.057999999999999996
 0.064
 0.068

julia> y = Yields.Zero(zero)
Yields.YieldCurve{Vector{Float64}, Vector{Int64}, Interpolations.Extrapolation{Float64, 1, Interpolations.GriddedInterpolation{Float64, 1, Float64, Interpolations.Gridded{Interpolations.Linear{Interpolations.Throw{Interpolations.OnGrid}}}, Tuple{Vector{Float64}}}, Interpolations.Gridded{Interpolations.Linear{Interpolations.Throw{Interpolations.OnGrid}}}, Interpolations.Line{Nothing}}}([0.05, 0.057999999999999996, 0.064, 0.068], [1, 2, 3, 4], 5-element extrapolate(interpolate((::Vector{Float64},), ::Vector{Float64}, Gridded(Linear())), Line()) with element type Float64:
 1.0
 0.9523809523809523
 0.8933644462391144
 0.8301854472236896
 0.7686258551392083)

julia> @benchmark discount($y,1)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  5.625 ns … 22.834 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.750 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.815 ns ±  0.843 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

           ▆    █    ▆    ▃   ▂                              ▁
  ▃▁▁▁█▁▁▁▁█▁▁▁▁█▁▁▁▁█▁▁▁▁█▁▁▁█▁▁▁▁█▁▁▁▁█▁▁▁▁▆▁▁▁▁▄▁▁▁▁▅▁▁▁▄ █
  5.62 ns      Histogram: log(frequency) by time     6.12 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
 ```

After:
```
julia> @benchmark discount($y,1)
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):  10.218 ns … 35.661 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.302 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.530 ns ±  1.779 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▄▁                                                         ▁
  █████▆▄▄▄▁▁▁▃▁▁▁▁▁▁▁▁▃▄▃▃▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▃▃▁▃▃▃▃▁▃▃▄▃▃▁▃▄ █
  10.2 ns      Histogram: log(frequency) by time      21.8 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
 ```

 Previously, calling `discount` on the curve in this example would have negative discount factor in the non-local extrapolated region.

 An alertnative could have been to precompute a discount factor and still use an interpolation on a discount curve, but that would require making judgements about the quantity and position of points outside of the given time range.