### PR TITLE
Clarify separation between Rate and AbstractYield

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Rate(0.05, Yields.Periodic(2))       # 5% compounded twice per period
 Yields.Periodic(0.05, 2)             # alternate constructor
 
 # construct a vector of rates with the given compounding
-Rate.(0.02,0.03,0.04,Yields.Periodic(2)) 
+Rate.([0.02,0.03,0.04],Yields.Periodic(2)) 
 ```
 
 ### Yields

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -55,7 +55,7 @@ Rate(0.05, Periodic(2))       # 5% compounded twice per period
 Periodic(0.05, 2)             # alternate constructor
 
 # construct a vector of rates with the given compounding
-Rate.(0.02,0.03,0.04,Periodic(2)) 
+Rate.([0.02,0.03,0.04],Periodic(2)) 
 ```
 
 ### Yields

--- a/src/Rate.jl
+++ b/src/Rate.jl
@@ -168,3 +168,59 @@ end
 function Base.isapprox(a::T, b::N; atol::Real = 0, rtol::Real = atol > 0 ? 0 : √eps()) where {T<:Rate,N<:Rate}
     return isapprox(convert(b.compounding, a), b; atol, rtol)
 end
+
+"""
+    discount(rate, t)
+    discount(rate, from, to)
+
+Discount `rate` for a time `t` or for an interval `(from, to)`. If `rate` is not a `Rate` it is converted to it. 
+
+# Examples
+
+```julia-repl
+julia> discount(0.03, 10)
+0.7440939148967249
+
+julia> discount(Periodic(0.03, 2), 10)
+0.7424704182237725
+
+julia> discount(Continuous(0.03), 10)
+0.7408182206817179
+
+julia> discount(0.03, 5, 10)
+0.8626087843841639
+```
+"""
+
+discount(rate, t) = discount(Rate(rate), t)
+discount(rate::Rate{<:Real, <:Continuous}, t) = exp(-rate.value * t)
+discount(rate::Rate{<:Real, <:Periodic}, t) = (1 + rate.value / rate.compounding.frequency)^(-rate.compounding.frequency * t)
+discount(rate, from, to) = discount(rate, to - from)
+
+"""
+    accumulation(rate, t)
+    accumulation(rate, from, to)
+
+Accumulate `rate` for a time `t` or for an interval `(from, to)`. If `rate` is not a `Rate` it is converted to it. 
+
+    # Examples
+
+```julia-repl
+julia> accumulation(0.03, 10)
+1.3439163793441222
+
+julia> accumulation(Periodic(0.03, 2), 10)
+1.3468550065500535
+
+julia> accumulation(Continuous(0.03), 10)
+1.3498588075760032
+
+julia> accumulation(0.03, 5, 10)
+1.1592740743
+```
+"""
+
+accumulation(rate, t) = accumulation(Rate(rate), t)
+accumulation(rate::Rate{<:Real, <:Continuous}, t) = exp(rate.value * t)
+accumulation(rate::Rate{<:Real, <:Periodic}, t) = (1 + rate.value / rate.compounding.frequency)^(rate.compounding.frequency * t)
+accumulation(rate, from, to) = accumulation(rate, to - from)

--- a/src/Rate.jl
+++ b/src/Rate.jl
@@ -82,7 +82,7 @@ end
 
 Rate is a type that encapsulates an interest `rate` along with its compounding `frequency`.
 
-Periodic rates can be constructed via `Rate(rate,frequency)` or `Rate(rate,Periodic(frequency))`.
+Periodic rates can be constructed via `Rate(rate,frequency)` or `Rate(rate,Periodic(frequency))`. If not given a second argument, `Rate(rate)` is equivalent to `Rate(rate,Periodic(1))`.
 
 Continuous rates can be constructed via `Rate(rate, Inf)` or `Rate(rate,Continuous())`.
 
@@ -173,7 +173,7 @@ end
     discount(rate, t)
     discount(rate, from, to)
 
-Discount `rate` for a time `t` or for an interval `(from, to)`. If `rate` is not a `Rate` it is converted to it. 
+Discount `rate` for a time `t` or for an interval `(from, to)`. If `rate` is not a `Rate`, it will be assumed to be a `Periodic` rate compounded once per period, i.e. `Periodic(rate,1)`. 
 
 # Examples
 
@@ -201,7 +201,7 @@ discount(rate, from, to) = discount(rate, to - from)
     accumulation(rate, t)
     accumulation(rate, from, to)
 
-Accumulate `rate` for a time `t` or for an interval `(from, to)`. If `rate` is not a `Rate` it is converted to it. 
+Accumulate `rate` for a time `t` or for an interval `(from, to)`. If `rate` is not a `Rate`, it will be assumed to be a `Periodic` rate compounded once per period, i.e. `Periodic(rate,1)`. 
 
     # Examples
 

--- a/src/Rate.jl
+++ b/src/Rate.jl
@@ -74,7 +74,6 @@ struct Rate{N<:Real,T<:CompoundingFrequency}
     compounding::T
 end
 
-# Base.:==(r1::Rate,r2::Rate) = (r1.value == r2.value) && (r1.compounding == r2.compounding)
 
 """
     Rate(rate[,frequency=1])

--- a/src/boostrap.jl
+++ b/src/boostrap.jl
@@ -71,16 +71,13 @@ function Constant(rate::T, cf::C = Periodic(1)) where {T<:Real,C<:CompoundingFre
 end
 
 Base.zero(c::Constant, time) = c.rate
-Base.zero(c::Constant, time, cf::C) where {C<:CompoundingFrequency} = convert(cf, c.rate)
+Base.zero(c::Constant, time, cf::CompoundingFrequency) = convert(cf, c.rate)
 rate(c::Constant) = c.rate
 rate(c::Constant, time) = c.rate
-discount(c::T, time) where {T<:Real} = discount(Constant(c), time)
-discount(r::Constant, time) = 1 / accumulation(r, time)
-
-accumulation(r::Constant, time) = accumulation(r.rate.compounding, r, time)
-accumulation(c::T, time) where {T>:Real} = accumulation(Constant(c), time)
-accumulation(::Continuous, r::Constant, time) = exp(rate(r.rate) * time)
-accumulation(::Periodic, r::Constant, time) = (1 + rate(r.rate) / r.rate.compounding.frequency)^(r.rate.compounding.frequency * time)
+discount(r::Constant, time) = discount(r.rate, time)
+discount(r::Constant, from, to) = discount(r.rate, to - from)
+accumulation(r::Constant, time) = accumulation(r.rate, time)
+accumulation(r::Constant, from, to) = accumulation(r.rate, to - from)
 
 """
     Step(rates,times)

--- a/test/Rate.jl
+++ b/test/Rate.jl
@@ -24,10 +24,13 @@
 
     @testset "rate equality" begin
         a = Yields.Periodic(0.02, 2)
+        a_eq = Yields.Periodic((1+.02/2)^2-1, 1)
         b = Yields.Periodic(0.03, 2)
         c = Yields.Continuous(0.02)
 
         @test a == a
+        @test !(a == a_eq) # not equal due to floating point error
+        @test_broken a ≈ a_eq
         @test a != b
         @test ~(a ≈ b)
         @test (a ≈ a)

--- a/test/Rate.jl
+++ b/test/Rate.jl
@@ -35,8 +35,8 @@
 
     end
 
-    @testset "discounting and accumulation" begin
-        t = 2.46
+    @testset "discounting and accumulation" for t in [-1.3, 2.46, 6.7]
+        
         unspecified_rate = 0.035
         periodic_rate = Yields.Periodic(0.02, 2)
         continuous_rate = Yields.Continuous(0.03)

--- a/test/Rate.jl
+++ b/test/Rate.jl
@@ -34,4 +34,31 @@
         @test ~(a ≈ c)
 
     end
+
+    @testset "discounting and accumulation" begin
+        t = 2.46
+        unspecified_rate = 0.035
+        periodic_rate = Yields.Periodic(0.02, 2)
+        continuous_rate = Yields.Continuous(0.03)
+
+        @test discount(unspecified_rate, t) ≈ (1 + 0.035)^(-t)
+        @test discount(periodic_rate, t) ≈ (1 + 0.02 / 2)^(-t * 2)
+        @test discount(continuous_rate, t) ≈ exp(-0.03 * t)
+
+        @test accumulation(unspecified_rate, t) ≈ (1 + 0.035)^t
+        @test accumulation(periodic_rate, t) ≈ (1 + 0.02 / 2)^(t * 2)
+        @test accumulation(continuous_rate, t) ≈ exp(0.03 * t)
+
+    end
+
+    @testset "rate over interval" begin
+        
+        from = -0.45
+        to = 3.4
+        rate = 0.15
+
+        @test discount(rate, from, to) ≈ discount(rate, to - from)
+        @test accumulation(rate, from, to) ≈ accumulation(rate, to - from)
+        
+    end
 end

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -23,8 +23,8 @@
         end
 
         @testset "broadcasting" begin
-            @test all(discount.(yield, [1, 2, 3]) .== 1 ./ 1.05 .^ (1:3))
-            @test all(accumulation.(yield, [1, 2, 3]) .== 1.05 .^ (1:3))
+            @test all(discount.(yield, [1, 2, 3]) .≈ 1 ./ 1.05 .^ (1:3))
+            @test all(accumulation.(yield, [1, 2, 3]) .≈ 1.05 .^ (1:3))
         end
 
         @testset "constant accumulation time: $time" for time in [0, 0.5, 1, 10]
@@ -137,8 +137,8 @@
         @test discount(y, 2) ≈ 1 / 1.058^2
 
         @testset "broadcasting" begin
-            @test all(isapprox.(discount.(y, [1, 2]), [1 / 1.05, 1 / 1.058^2], rtol = 1e-14))
-            @test all(isapprox.(accumulation.(y, [1, 2]), [1.05, 1.058^2], rtol = 1e-14))
+            @test all(discount.(y, [1, 2]) .≈ [1 / 1.05, 1 / 1.058^2])
+            @test all(accumulation.(y, [1, 2]) .≈ [1.05, 1.058^2])
         end
 
     end

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -11,8 +11,8 @@
 
         @testset "constant discount time: $time" for time in [0, 0.5, 1, 10]
             @test discount(yield, time) ≈ 1 / (1.05)^time
-            @test discount(rate, time) ≈ 1 / (1.05)^time
-            @test discount(rate, 0, time) ≈ 1 / (1.05)^time
+            @test discount(yield, 0, time) ≈ 1 / (1.05)^time
+            @test discount(yield, 3, time + 3) ≈ 1 / (1.05)^time
         end
         @testset "constant discount scalar time: $time" for time in [0, 0.5, 1, 10]
             @test discount(0.05, time) ≈ 1 / (1.05)^time
@@ -29,25 +29,8 @@
 
         @testset "constant accumulation time: $time" for time in [0, 0.5, 1, 10]
             @test accumulation(yield, time) ≈ 1 * 1.05^time
-            @test accumulation(rate, time) ≈ 1 * 1.05^time
-            @test accumulation(rate, 0, time) ≈ 1 * 1.05^time
-        end
-
-        @testset "CompoundingFrequency" begin
-            @testset "Continuous" begin
-                cnst = Yields.Constant(Yields.Continuous(0.05))
-                @test accumulation(cnst, 1) == exp(0.05)
-                @test accumulation(cnst, 2) == exp(0.05 * 2)
-                @test discount(cnst, 2) == 1 / exp(0.05 * 2)
-            end
-
-            @testset "Periodic" begin
-                p = Yields.Constant(Rate(0.05, Yields.Periodic(2)))
-                @test accumulation(p, 1) == (1 + 0.05 / 2)^(1 * 2)
-                @test accumulation(p, 2) == (1 + 0.05 / 2)^(2 * 2)
-                @test discount(p, 2) == 1 / (1 + 0.05 / 2)^(2 * 2)
-
-            end
+            @test accumulation(yield, 0, time) ≈ 1 * 1.05^time
+            @test accumulation(yield, 3, time + 3) ≈ 1 * 1.05^time
         end
 
 
@@ -154,8 +137,8 @@
         @test discount(y, 2) ≈ 1 / 1.058^2
 
         @testset "broadcasting" begin
-            @test all(discount.(y, [1, 2]) .≈ [1 / 1.05, 1 / 1.058^2])
-            @test all(accumulation.(y, [1, 2]) .≈ [1.05, 1.058^2])
+            @test all(isapprox.(discount.(y, [1, 2]), [1 / 1.05, 1 / 1.058^2], rtol = 1e-14))
+            @test all(isapprox.(accumulation.(y, [1, 2]), [1.05, 1.058^2], rtol = 1e-14))
         end
 
     end


### PR DESCRIPTION
This supersedes #56.

`Rate` is given `discount` and `accumulation` methods and `Constant` now refers to them and not the other way around.

The methods in `generics.jl` were made specific to `AbstractYield`s since their `Rate` counterparts are now explicitly given in `rate.jl`.

A cleanup of tests of `Constant` was not done, but it could be argued that they should be reduced a little, since they partly tested functionality that now belongs to `Rate`.