### PR TITLE
Makes `Rate`s add/subtract with scalars 

### DIFF
--- a/test/ActuaryUtilities.jl
+++ b/test/ActuaryUtilities.jl
@@ -1,0 +1,16 @@
+using ActuaryUtilities
+
+@testset "ActuaryUtilities.jl integration tests" begin
+    cfs = [5, 5, 105]
+    times    = [1, 2, 3]
+
+    discount_rates  = [0.03,Yields.Periodic(0.03,1), Yields.Constant(0.03)]
+
+    for d in discount_rates
+        @test present_value(d, cfs, times)           ≈ 105.65722270978935
+        @test duration(Macaulay(), d, cfs, times)    ≈ 2.86350467067113
+        @test duration(d, cfs, times)                ≈ 2.7801016220108057
+        @test convexity(d, cfs, times)               ≈ 10.625805482685939
+    end
+end
+    

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+ActuaryUtilities = "bdd23359-8b1c-4f88-b89b-d11982a786f4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Yields = "d7e99b2f-e7f3-4d9e-9f01-2338fc023ad3"
+
+[compat]
+ActuaryUtilities = "~2"

--- a/test/Rate.jl
+++ b/test/Rate.jl
@@ -65,4 +65,33 @@
         @test accumulation(rate, from, to) ≈ accumulation(rate, to - from)
         
     end
+
+    @testset "rate addition/subtraction" begin
+
+        a = 0.03
+        b = 0.02
+        
+        @testset "addition" begin
+            c(x) = Yields.Continuous(x)
+            p(x) = Yields.Periodic(x, 1)
+
+            @test c(a) + b ≈ Yields.Continuous(0.05)
+            @test a + c(b) ≈ Yields.Continuous(0.05)
+            
+            @test p(a) + b ≈ Yields.Periodic(0.05,1)
+            @test a + p(b) ≈ Yields.Periodic(0.05,1)
+        end
+
+        @testset "subtraction" begin
+            c(x) = Yields.Continuous(x)
+            p(x) = Yields.Periodic(x, 1)
+
+            @test c(a) - b ≈ Yields.Continuous(0.01)
+            @test a - c(b) ≈ Yields.Continuous(0.01)
+            
+            @test p(a) - b ≈ Yields.Periodic(0.01,1)
+            @test a - p(b) ≈ Yields.Periodic(0.01,1)
+        end
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,3 +6,4 @@ include("bootstrap.jl")
 include("RateCombination.jl")
 include("SmithWilson.jl")
 
+include("ActuaryUtilities.jl")


### PR DESCRIPTION
This fixes something that broke when switching the `Constant` <-> `Rate` logic in #80 wherein functions like `duration` and `convexity` could no longer add a scalar to the rate used in the present value function. I.e.:

`Yields.Periodic(0.03,1) + 0.02` would not work to make `Yields.Periodic(0.05,1)`


The alternative would be to force downstream packages/users to always specifcy the kind of rate when adding, but I think it's not very ambiguous if you have a concrete `Rate` and a scalar added together what it should do.

We can debate this in #75, but I am merging this for now since it broke ActuaryUtilities usage.

Tests aren't passing because ActuaryUtilities isn't compatiable with `master` Yields@0.10. A compatible version of ActuaryUtilities is in the process of being registered now.