### PR TITLE
WIP: Par Rates (`Yields.par(curve,time)` function)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,14 @@ version = "1.0.1"
 BSplineKit = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
+BSplineKit = "^0.8"
 ForwardDiff = "^0.10"
 UnicodePlots = "^2"
 julia = "^1.6"
-BSplineKit = "^0.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -4,6 +4,7 @@ import BSplineKit
 import ForwardDiff
 using LinearAlgebra
 using UnicodePlots
+using Roots
 
 # don't export type, as the API of Yields.Zero is nicer and 
 # less polluting than Zero and less/equally verbose as ZeroYieldCurve or ZeroCurve

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -202,7 +202,7 @@ end
 """
     Par(rates, maturities; interpolation=CubicSpline())
 
-Construct a curve given a set of bond equivalent yields and the corresponding maturities. Assumes that maturities <= 1 year do not pay coupons and that after one year, pays coupons with frequency equal to the CompoundingFrequency of the corresponding rate.
+Construct a curve given a set of bond equivalent yields and the corresponding maturities. Assumes that maturities <= 1 year do not pay coupons and that after one year, pays coupons with frequency equal to the CompoundingFrequency of the corresponding rate (normally the default for a `Rate` is `1`, but when constructed via `Par` the default compounding Frequency is `2`).
 
 See [`bootstrap`](@ref) for more on the `interpolation` parameter, which is set to `CubicSpline()` by default.
 
@@ -233,7 +233,7 @@ function Par(rates::Vector{<:Rate}, maturities; interpolation=CubicSpline())
 end
 
 function Par(rates::Vector{T}, maturities; interpolation=CubicSpline()) where {T<:Real}
-    return Par(Rate.(rates), maturities; interpolation)
+    return Par(Yields.Periodic.(rates,2), maturities; interpolation)
 end
 
 

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -350,6 +350,7 @@ end
 Calculate the par yield for maturity `time` for the given `curve` and `frequency`. Returns a `Rate` object with periodicity corresponding to the `frequency`. The exception to this is if `time` is less than what the payments allowed by frequency (e.g. a time `0.5` but with frequency `1`) will effectively assume frequency equal to 1 over `time`.
 
 # Examples
+
 julia> c = Yields.Constant(0.04);
 
 julia> Yields.par(c,4)

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -367,7 +367,6 @@ Yields.Rate{Float64, Yields.Periodic}(0.039374942589460726, Yields.Periodic(5))
 julia> Yields.par(c,2.5)
 Yields.Rate{Float64, Yields.Periodic}(0.03960780543711406, Yields.Periodic(2))
 
-
 """
 function par(curve, time; frequency=2)
     mat_disc = discount(curve, 0, time)
@@ -396,7 +395,6 @@ function irr_newton(cashflows, times)
     # use newton's method with hand-coded derivative
     f(r) =  sum(cf * exp(-r*t) for (cf,t) in zip(cashflows,times))
     f′(r) = sum(-t*cf * exp(-r*t) for (cf,t) in zip(cashflows,times) if t > 0)
-    # r = Roots.solve(Roots.ZeroProblem((f,f′), 0.0), Roots.Newton())
     r = Roots.newton(x->(f(x),f(x)/f′(x)),0.0)
     return Yields.Periodic(exp(r)-1,1)
 

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -348,6 +348,26 @@ end
     par(curve,time;frequency=2)
 
 Calculate the par yield for maturity `time` for the given `curve` and `frequency`. Returns a `Rate` object with periodicity corresponding to the `frequency`. The exception to this is if `time` is less than what the payments allowed by frequency (e.g. a time `0.5` but with frequency `1`) will effectively assume frequency equal to 1 over `time`.
+
+# Examples
+julia> c = Yields.Constant(0.04);
+
+julia> Yields.par(c,4)
+Yields.Rate{Float64, Yields.Periodic}(0.03960780543711406, Yields.Periodic(2))
+
+julia> Yields.par(c,4;frequency=1)
+Yields.Rate{Float64, Yields.Periodic}(0.040000000000000036, Yields.Periodic(1))
+
+julia> Yields.par(c,0.6;frequency=4)
+Yields.Rate{Float64, Yields.Periodic}(0.039413626195875295, Yields.Periodic(4))
+
+julia> Yields.par(c,0.2;frequency=4)
+Yields.Rate{Float64, Yields.Periodic}(0.039374942589460726, Yields.Periodic(5))
+
+julia> Yields.par(c,2.5)
+Yields.Rate{Float64, Yields.Periodic}(0.03960780543711406, Yields.Periodic(2))
+
+
 """
 function par(curve, time; frequency=2)
     mat_disc = discount(curve, 0, time)

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -354,12 +354,12 @@ function par(curve, time; frequency=2)
     coup_times = coupon_times(time,frequency)
     coupon_pv = sum(discount(curve,0,t) for t in coup_times)
     Δt = step(coup_times)
-    frequency_inner = max(1 / Δt, frequency)
     r = (1-mat_disc) / coupon_pv
     cfs = [t == last(coup_times) ? 1+r : r for t in coup_times]
     cfs = [-1;cfs]
     r = irr_newton(cfs,[0;coup_times])
-    r = convert(Periodic(frequency),r)
+    frequency_inner = min(1,max(1 / Δt, frequency))
+    r = convert(Periodic(frequency_inner),r)
     return r
 end
 

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -342,3 +342,23 @@ function OIS(rates::Vector{<:Rate}, maturities ; interpolation=CubicSpline())
         bootstrap(rates, maturities, [m <= 1 ? nothing : 1 / 4 for m in maturities], interpolation)
     )
 end
+
+
+"""
+    par(curve,time;frequency=2)
+
+Calculate the par yield for maturity `time` for the given `curve` and `frequency`. Returns a `Rate` object with periodicity corresponding to the `frequency`. The exception to this is if `time` is less than what the payments allowed by frequency (e.g. a time `0.5` but with frequency `1`) will effectively assume frequency equal to 1 over `time`.
+"""
+function par(curve, time; frequency=2)
+    @show par_pv = discount(curve, 0, time)
+
+    # when the time is less than otherwise allowed by the frequency (e.g. )
+    Δt = min(1 / frequency,time)
+    @show start = max(rem(time,Δt),Δt)
+    frequency_inner = max(1 / Δt, frequency)
+    @show start:Δt:time, length(start:Δt:time)
+    @show coupon_pv = sum(discount(curve,0,t) for t in start:Δt:time)
+    @show r = Periodic((1-par_pv) * frequency_inner / coupon_pv,frequency_inner)
+    r = convert(Periodic(frequency),r)
+    return r
+end

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -358,7 +358,7 @@ function par(curve, time; frequency=2)
     cfs = [t == last(coup_times) ? 1+r : r for t in coup_times]
     cfs = [-1;cfs]
     r = irr_newton(cfs,[0;coup_times])
-    frequency_inner = min(1,max(1 / Δt, frequency))
+    frequency_inner = min(1/Δt,max(1 / Δt, frequency))
     r = convert(Periodic(frequency_inner),r)
     return r
 end

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -303,6 +303,8 @@
             @test Yields.par(c,t) ≈ Yields.Periodic(0.04,1)
             @test Yields.par(c,t,frequency=4) ≈ Yields.Periodic(0.04,1)
         end
+
+        @test Yields.par(c,0.6) ≈ Yields.Periodic(0.04,1)
     end
 
 end

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -123,6 +123,15 @@
 
     end
 
+    @testset "Hull" begin
+        # Par Yield, pg 85
+
+        c = Yields.Par(Yields.Periodic.([0.0687,0.0687],2), [2,3])
+
+        @test Yields.par(c,2) ≈ Yields.Periodic(0.0687,2)
+
+    end
+
     @testset "simple rate and forward" begin
         # Risk Managment and Financial Institutions, 5th ed. Appendix B
 
@@ -304,6 +313,20 @@
         end
 
         @test Yields.par(c,0.6) ≈ Yields.Periodic(0.04,1)
+
+        @testset "round trip" begin
+            maturity = collect(1:10)
+
+            par = [6.0, 8.0, 9.5, 10.5, 11.0, 11.25, 11.38, 11.44, 11.48, 11.5] ./ 100
+
+            curve = Yields.Par(par,maturity)
+
+            for (p,m) in zip(par,maturity)
+                @test Yields.par(curve,m) ≈ Yields.Periodic(p,2) atol = 0.0001
+            end
+        end
+
+
     end
 
 end

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -298,7 +298,6 @@
 
         c = Yields.Constant(0.04)
         @testset "misc combinations" for t in 0.5:0.5:5 
-            @show t
             @test Yields.par(c,t;frequency=1) ≈ Yields.Periodic(0.04,1)
             @test Yields.par(c,t) ≈ Yields.Periodic(0.04,1)
             @test Yields.par(c,t,frequency=4) ≈ Yields.Periodic(0.04,1)

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -280,6 +280,19 @@
         end
     end
 
+    @testset "par" begin
+        
+        # https://quant.stackexchange.com/questions/57608/how-to-compute-par-yield-from-zero-rate-curve
+        c = Yields.Zero(Yields.Continuous.([0.02,0.025,0.03,0.035]),0.5:0.5:2)
+        @test Yields.par(c,2) ≈ Yields.Periodic(0.03508591,2) atol = 0.000001
 
+        c = Yields.Constant(0.04)
+        for t in 0.5:0.5:5 
+            @show t
+            @test Yields.par(c,t;frequency=1) ≈ Yields.Periodic(0.04,1)
+            @test Yields.par(c,t) ≈ Yields.Periodic(0.04,1)
+            @test Yields.par(c,t,frequency=4) ≈ Yields.Periodic(0.04,1)
+        end
+    end
 
 end

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -281,13 +281,23 @@
     end
 
     @testset "par" begin
+        @testset "first payment logic" begin
+            ct = Yields.coupon_times
+            @test ct(0.5,1) ≈ 0.5:1:0.5
+            @test ct(1.5,1) ≈ 0.5:1:1.5
+            @test ct(0.75,1) ≈ 0.75:1:0.75
+            @test ct(1,1) ≈ 1:1:1
+            @test ct(1,2) ≈ 0.5:0.5:1.0
+            @test ct(0.5,2) ≈ 0.5:0.5:0.5
+            @test ct(1.5,2) ≈ 0.5:0.5:1.5
+        end
         
         # https://quant.stackexchange.com/questions/57608/how-to-compute-par-yield-from-zero-rate-curve
         c = Yields.Zero(Yields.Continuous.([0.02,0.025,0.03,0.035]),0.5:0.5:2)
         @test Yields.par(c,2) ≈ Yields.Periodic(0.03508591,2) atol = 0.000001
 
         c = Yields.Constant(0.04)
-        for t in 0.5:0.5:5 
+        @testset "misc combinations" for t in 0.5:0.5:5 
             @show t
             @test Yields.par(c,t;frequency=1) ≈ Yields.Periodic(0.04,1)
             @test Yields.par(c,t) ≈ Yields.Periodic(0.04,1)


### PR DESCRIPTION
Adds a new function: `Yields.par(curve,time;frequency)`:

```
"""
    par(curve,time;frequency=2)

Calculate the par yield for maturity `time` for the given `curve` and `frequency`. Returns a `Rate` object with periodicity corresponding to the `frequency`. The exception to this is if `time` is less than what the payments allowed by frequency (e.g. a time `0.5` but with frequency `1`) will effectively assume frequency equal to 1 over `time`.

# Examples
julia> c = Yields.Constant(0.04);

julia> Yields.par(c,4)
Yields.Rate{Float64, Yields.Periodic}(0.03960780543711406, Yields.Periodic(2))

julia> Yields.par(c,4;frequency=1)
Yields.Rate{Float64, Yields.Periodic}(0.040000000000000036, Yields.Periodic(1))

julia> Yields.par(c,0.6;frequency=4)
Yields.Rate{Float64, Yields.Periodic}(0.039413626195875295, Yields.Periodic(4))

julia> Yields.par(c,0.2;frequency=4)
Yields.Rate{Float64, Yields.Periodic}(0.039374942589460726, Yields.Periodic(5))

julia> Yields.par(c,2.5)
Yields.Rate{Float64, Yields.Periodic}(0.03960780543711406, Yields.Periodic(2))

"""
```

Todo before merging:

- [x] add round trip tests with `Yields.Par`

Todo as follow-up PRs
- [ ] Should move IRR solvers into new upstream package given duplicate usage in ActuaryUtilities and Yields
- [ ] Current Par implementation could be made more efficient (less allocations)