### PR TITLE
use repr instead of show as it's much easier to wrangle than somethin…

### DIFF
--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -257,7 +257,7 @@
         end
 
         # test that showing the curve doesn't error
-        @test isnothing(show(devnull, curve))
+        @test length(repr(curve)) > 0
 
         #     # https://www.federalreserve.gov/pubs/feds/2006/200628/200628abs.html
         #     # 2020-04-02 data


### PR DESCRIPTION
…g sent to an IO

It seems like an update to UnicodePlots (maybe?) meant that something was being returned in the prior test instead of `nothing`