### PR TITLE
Have Rate subtype AbstractYield and add `AbstractYieldCurve` to heirarchy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 version = "2.0.0"
 
 [deps]
+ActuaryUtilities = "bdd23359-8b1c-4f88-b89b-d11982a786f4"
 BSplineKit = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 version = "2.0.0"
 
 [deps]
-ActuaryUtilities = "bdd23359-8b1c-4f88-b89b-d11982a786f4"
 BSplineKit = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -6,14 +6,14 @@ CurrentModule = Yields
 
 ## Custom Curve Types
 
-Types that subtype `Yields.AbstractYield` should implement a few key methods:
+Types that subtype `Yields.AbstractYieldCurve` should implement a few key methods:
 
 - `discount(curve,to)` should return the discount factor for the given curve through time `to`
 
 For example:
 
 ```julia
-struct MyYield <: Yields.AbstractYield
+struct MyYield <: Yields.AbstractYieldCurve
     rate
 end
 
@@ -21,7 +21,7 @@ Yields.discount(c::MyYield,to) = exp(-c.rate * to)
 ```
 
 
-By defining the `discount` method as above and subtyping `Yields.AbstractYield`, Yields.jl has generic functions that will work:
+By defining the `discount` method as above and subtyping `Yields.AbstractYieldCurve`, Yields.jl has generic functions that will work:
 
 - `zero(curve,to)` returns the zero rate at time `to`
 - `discount(curve,from,to)` is the discount factor between the two timepoints
@@ -37,11 +37,11 @@ In some contexts, such as creating performant iteration of curves in [EconomicSc
 Sometimes it is most natural or convenient to expect a certain kind of `Rate` from a given curve. In many advanced use-cases (differentiation, stochastic rates), `Continuous` rates are most natural. For this reason, the `DEFAULT_COMPOUNDING` constant within Yields.jl is $(Yields.DEFAULT_COMPOUNDING). Two comments on this:
 
 1. Becuase Yields.jl returns `Rate` types (e.g. `Rate(0.05,Continuous()`) instead of single scalars (e.g. `0.05`) functions within the `JuliaActuary` universe (e.g. `ActuaryUtilities.present_value) know how to treat rates differently and in general users should not ever need to worry about converting between different compounding conventions.
-2. Developers implementing new `AbstractYield` types can define their own default. For example, using the `MyYield` example above:
+2. Developers implementing new `AbstractYieldCurve` types can define their own default. For example, using the `MyYield` example above:
 
   - `__ratetype(::Type{MyYield}) = Yields.Rate{Float64, Continuous}`
 
-If the `CompoundingFrequency` is `Continuous`, then it's currently not necessary to define `__ratetype`, as it will fall back onto the generic method defined for `AbstractYield`s.
+If the `CompoundingFrequency` is `Continuous`, then it's currently not necessary to define `__ratetype`, as it will fall back onto the generic method defined for `AbstractYieldCurve`s.
 
 If the preferred compounding frequency is `Periodic`, then you must either define the methods (`zero`, `forward`,...) for your type or to use the generic methods then you must define `Yields.CompoundingFrequency(curve::MyCurve)` to return the `Periodic` compounding datatype of the rates to return. 
 

--- a/src/AbstractYield.jl
+++ b/src/AbstractYield.jl
@@ -14,19 +14,3 @@ It can be be constructed via:
 - typical constant maturity treasury (CMT) curve with [`CMT`](@ref)
 """
 abstract type AbstractYield end
-
-# make interest curve broadcastable so that you can broadcast over multiple`time`s in `interest_rate`
-Base.Broadcast.broadcastable(ic::T) where {T<:AbstractYield} = Ref(ic)
-
-struct BootstrappedYieldCurve{T,U,V} <: AbstractYield
-    rates::T
-    maturities::U
-    zero::V # function time -> continuous zero rate
-end
-discount(yc::T, time) where {T<:BootstrappedYieldCurve} = exp(-yc.zero(time) * time)
-
-# internal function (will be used in EconomicScenarioGenerators)
-# defines the rate output given just the type of curve
-__ratetype(curve::T) where {T<:AbstractYield} = __ratetype(typeof(curve))
-__ratetype(::Type{T}) where {T<:AbstractYield} = Yields.Rate{Float64, typeof(DEFAULT_COMPOUNDING)}
-__ratetype(::Type{BootstrappedYieldCurve{T,U,V}}) where {T,U,V}= Yields.Rate{Float64, typeof(DEFAULT_COMPOUNDING)}

--- a/src/AbstractYield.jl
+++ b/src/AbstractYield.jl
@@ -14,3 +14,5 @@ It can be be constructed via:
 - typical constant maturity treasury (CMT) curve with [`CMT`](@ref)
 """
 abstract type AbstractYield end
+
+abstract type AbstractYieldCurve <: AbstractYield end

--- a/src/Rate.jl
+++ b/src/Rate.jl
@@ -69,7 +69,7 @@ See also: [`Continuous`](@ref)
 """
 Periodic(x, frequency) = Rate(x, Periodic(frequency))
 
-struct Rate{N<:Real,T<:CompoundingFrequency}
+struct Rate{N<:Real,T<:CompoundingFrequency} <: AbstractYield
     value::N
     compounding::T
 end

--- a/src/Rate.jl
+++ b/src/Rate.jl
@@ -227,6 +227,7 @@ accumulation(rate::Rate{<:Real, <:Continuous}, t) = exp(rate.value * t)
 accumulation(rate::Rate{<:Real, <:Periodic}, t) = (1 + rate.value / rate.compounding.frequency)^(rate.compounding.frequency * t)
 accumulation(rate, from, to) = accumulation(rate, to - from)
 
+Base.zero(rate::T,t) where {T<:Rate} = rate
 
 """
     +(Yields.Rate, T<:Real)

--- a/src/RateCombination.jl
+++ b/src/RateCombination.jl
@@ -1,5 +1,5 @@
 ## Curve Manipulations
-struct RateCombination{T,U,V} <: AbstractYield
+struct RateCombination{T,U,V} <: AbstractYieldCurve
     r1::T
     r2::U
     op::V
@@ -21,11 +21,11 @@ function Base.zero(rc::RateCombination, time, cf::C) where {C<:CompoundingFreque
 end
 
 """
-    Yields.AbstractYield + Yields.AbstractYield
+    Yields.AbstractYieldCurve + Yields.AbstractYieldCurve
 
 The addition of two yields will create a `RateCombination`. For `rate`, `discount`, and `accumulation` purposes the spot rates of the two curves will be added together.
 """
-function Base.:+(a::AbstractYield, b::AbstractYield)
+function Base.:+(a::AbstractYieldCurve, b::AbstractYieldCurve)
     return RateCombination(a, b, +)
 end
 
@@ -40,20 +40,20 @@ function Base.:+(a::Constant, b::Constant)
     )
 end
 
-function Base.:+(a::T, b) where {T<:AbstractYield}
+function Base.:+(a::T, b) where {T<:AbstractYieldCurve}
     return a + Constant(b)
 end
 
-function Base.:+(a, b::T) where {T<:AbstractYield}
+function Base.:+(a, b::T) where {T<:AbstractYieldCurve}
     return Constant(a) + b
 end
 
 """
-    Yields.AbstractYield - Yields.AbstractYield
+    Yields.AbstractYieldCurve - Yields.AbstractYieldCurve
 
 The subtraction of two yields will create a `RateCombination`. For `rate`, `discount`, and `accumulation` purposes the spot rates of the second curves will be subtracted from the first.
 """
-function Base.:-(a::AbstractYield, b::AbstractYield)
+function Base.:-(a::AbstractYieldCurve, b::AbstractYieldCurve)
     return RateCombination(a, b, -)
 end
 
@@ -68,10 +68,10 @@ function Base.:-(a::Constant, b::Constant)
     )
 end
 
-function Base.:-(a::T, b) where {T<:AbstractYield}
+function Base.:-(a::T, b) where {T<:AbstractYieldCurve}
     return a - Constant(b)
 end
 
-function Base.:-(a, b::T) where {T<:AbstractYield}
+function Base.:-(a, b::T) where {T<:AbstractYieldCurve}
     return Constant(a) - b
 end

--- a/src/SmithWilson.jl
+++ b/src/SmithWilson.jl
@@ -94,7 +94,7 @@ Required keyword arguments:
 - `ufr` is the Ultimate Forward Rate, the forward interest rate to which the yield curve tends, in continuous compounding convention. 
 - `α` is the parameter that governs the speed of convergence towards the Ultimate Forward Rate. It can be typed with `\\alpha[TAB]`
 """
-struct SmithWilson{TU<:AbstractVector,TQb<:AbstractVector} <: AbstractYield
+struct SmithWilson{TU<:AbstractVector,TQb<:AbstractVector} <: AbstractYieldCurve
     u::TU
     qb::TQb
     ufr

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -12,10 +12,10 @@ using Roots
 export rate, discount, accumulation, forward,
 LinearSpline, QuadraticSpline, Periodic, Continuous
 
+include("AbstractYield.jl")
 include("Rate.jl")
 const DEFAULT_COMPOUNDING = Yields.Continuous()
 
-include("AbstractYield.jl")
 include("utils.jl")
 include("bootstrap.jl")
 include("SmithWilson.jl")

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -1,5 +1,14 @@
 # bootstrapped class of curve methods
 
+struct BootstrappedYieldCurve{T,U,V} <: AbstractYield
+    rates::T
+    maturities::U
+    zero::V # function time -> continuous zero rate
+end
+discount(yc::T, time) where {T<:BootstrappedYieldCurve} = exp(-yc.zero(time) * time)
+
+__ratetype(::Type{BootstrappedYieldCurve{T,U,V}}) where {T,U,V}= Yields.Rate{Float64, typeof(DEFAULT_COMPOUNDING)}
+
 # Forward curves
 
 """

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -1,6 +1,6 @@
 # bootstrapped class of curve methods
 
-struct BootstrappedYieldCurve{T,U,V} <: AbstractYield
+struct BootstrappedYieldCurve{T,U,V} <: AbstractYieldCurve
     rates::T
     maturities::U
     zero::V # function time -> continuous zero rate
@@ -37,7 +37,7 @@ While `ForwardStarting` could be nested so that, e.g. the third period's curve i
 
 `ForwardStarting` is not used to construct a curve based on forward rates. See  [`Forward`](@ref) instead.
 """
-struct ForwardStarting{T,U} <: AbstractYield
+struct ForwardStarting{T,U} <: AbstractYieldCurve
     curve::U
     forwardstart::T
 end
@@ -67,7 +67,7 @@ julia> discount(y,2)
 0.9070294784580498     # 1 / (1.05) ^ 2
 ```
 """
-struct Constant{T} <: AbstractYield
+struct Constant{T} <: AbstractYieldCurve
     rate::T
 end
 __ratetype(::Type{Constant{T}}) where {T} = T
@@ -108,7 +108,7 @@ julia>rate(y,2.5)
 0.05
 ```
 """
-struct Step{R,T} <: AbstractYield
+struct Step{R,T} <: AbstractYieldCurve
     rates::R
     times::T
 end

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -6,28 +6,28 @@
 
 The discount factor for the yield curve `yc` for times `from` through `to`.
 """
-discount(yc::T, from, to) where {T<:AbstractYield}= discount(yc, to) / discount(yc, from)
+discount(yc::T, from, to) where {T<:AbstractYieldCurve}= discount(yc, to) / discount(yc, from)
 
 """
     forward(yc, from, to, CompoundingFrequency=Periodic(1))
 
 The forward `Rate` implied by the yield curve `yc` between times `from` and `to`.
 """
-function forward(yc::T, from, to) where {T<:AbstractYield}
+function forward(yc::T, from, to) where {T<:AbstractYieldCurve}
     return forward(yc, from, to, DEFAULT_COMPOUNDING)
 end
 
-function forward(yc::T, from, to, cf::CompoundingFrequency) where {T<:AbstractYield}
+function forward(yc::T, from, to, cf::CompoundingFrequency) where {T<:AbstractYieldCurve}
     r = Periodic((accumulation(yc, to) / accumulation(yc, from))^(1 / (to - from)) - 1, 1)
     return convert(cf, r)
 end
 
-function forward(yc::T, from) where {T<:AbstractYield}
+function forward(yc::T, from) where {T<:AbstractYieldCurve}
     to = from + 1
     return forward(yc, from, to)
 end
 
-function CompoundingFrequency(curve::T) where {T<:AbstractYield}
+function CompoundingFrequency(curve::T) where {T<:AbstractYieldCurve}
     return DEFAULT_COMPOUNDING
 end
 
@@ -37,11 +37,11 @@ end
 
 Return the zero rate for the curve at the given time.
 """
-function Base.zero(c::YC, time) where {YC<:AbstractYield} 
+function Base.zero(c::YC, time) where {YC<:AbstractYieldCurve} 
      zero(c, time, CompoundingFrequency(c))
 end
 
-function Base.zero(c::YC, time, cf::C) where {YC<:AbstractYield,C<:CompoundingFrequency}
+function Base.zero(c::YC, time, cf::C) where {YC<:AbstractYieldCurve,C<:CompoundingFrequency}
     df = discount(c, time)
     r = -log(df)/time
     return convert(cf, Continuous(r)) # c.zero is a curve of continuous rates represented as floats. explicitly wrap in continuous before converting
@@ -52,10 +52,10 @@ end
 
 The accumulation factor for the yield curve `yc` for times `from` through `to`.
 """
-function accumulation(yc::AbstractYield, time)
+function accumulation(yc::AbstractYieldCurve, time)
     return 1 ./ discount(yc, time)
 end
 
-function accumulation(yc::AbstractYield, from, to)
+function accumulation(yc::AbstractYieldCurve, from, to)
     return 1 ./ discount(yc, from, to)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,11 @@
 # make interest curve broadcastable so that you can broadcast over multiple`time`s in `interest_rate`
-Base.Broadcast.broadcastable(ic::T) where {T<:AbstractYield} = Ref(ic)
+Base.Broadcast.broadcastable(ic::T) where {T<:AbstractYieldCurve} = Ref(ic)
 
 
 # internal function (will be used in EconomicScenarioGenerators)
 # defines the rate output given just the type of curve
-__ratetype(curve::T) where {T<:AbstractYield} = __ratetype(typeof(curve))
-__ratetype(::Type{T}) where {T<:AbstractYield} = Yields.Rate{Float64, typeof(DEFAULT_COMPOUNDING)}
+__ratetype(curve::T) where {T<:AbstractYieldCurve} = __ratetype(typeof(curve))
+__ratetype(::Type{T}) where {T<:AbstractYieldCurve} = Yields.Rate{Float64, typeof(DEFAULT_COMPOUNDING)}
 
 # https://github.com/dpsanders/hands_on_julia/blob/master/during_sessions/Fractale%20de%20Newton.ipynb
 newton(f, f′, x) = x - f(x) / f′(x)
@@ -147,7 +147,7 @@ end
 # https://stackoverflow.com/questions/70043313/get-simple-name-of-type-in-julia?noredirect=1#comment123823820_70043313
 name(::Type{T}) where {T} = (isempty(T.parameters) ? T : T.name.wrapper)
 
-function Base.show(io::IO, curve::T) where {T<:AbstractYield}
+function Base.show(io::IO, curve::T) where {T<:AbstractYieldCurve}
     println() # blank line for padding
     r = zero(curve, 1)
     ylabel = isa(r.compounding, Continuous) ? "Continuous" : "Periodic($(r.compounding.frequency))"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,12 @@
+# make interest curve broadcastable so that you can broadcast over multiple`time`s in `interest_rate`
+Base.Broadcast.broadcastable(ic::T) where {T<:AbstractYield} = Ref(ic)
+
+
+# internal function (will be used in EconomicScenarioGenerators)
+# defines the rate output given just the type of curve
+__ratetype(curve::T) where {T<:AbstractYield} = __ratetype(typeof(curve))
+__ratetype(::Type{T}) where {T<:AbstractYield} = Yields.Rate{Float64, typeof(DEFAULT_COMPOUNDING)}
+
 # https://github.com/dpsanders/hands_on_julia/blob/master/during_sessions/Fractale%20de%20Newton.ipynb
 newton(f, f′, x) = x - f(x) / f′(x)
 function solve(g, g′, x0, max_iterations = 100)
@@ -80,7 +89,7 @@ function _bootstrap_inner(rates, maturities, settlement_frequency, interpolation
         end
 
     end
-    zero_vec = -log.(discount_vec) ./ maturities
+    zero_vec = -log.(clamp.(discount_vec,0.00001,1)) ./ maturities
     return interpolation_function([0.0; maturities], [first(zero_vec); zero_vec])
 end
 

--- a/test/Rate.jl
+++ b/test/Rate.jl
@@ -66,7 +66,23 @@
         
     end
 
-    @testset "rate addition/subtraction" begin
+    @testset "AbstractYield Interface" begin
+        c = Continuous(0.03)
+        p = Periodic(0.04,2)
+
+        @test zero(c,2) ≈ c
+        @test zero(p,2) ≈ p
+
+        @test discount(c,2) ≈ exp(-2*0.03)
+        @test discount(p,2) ≈ 1 / (1 + .04/2)^(2*2)
+
+        @test discount(c,2) ≈ 1 / accumulation(c,2)
+        @test discount(p,2) ≈ 1 / accumulation(p,2)
+
+
+    end
+
+    @testset "rate algebra" begin
 
         a = 0.03
         b = 0.02

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -1,7 +1,7 @@
 # test extending type and that various generic methods are defined 
-# to fulfill the API of AbstractYield
+# to fulfill the API of AbstractYieldCurve
 @testset "generic methods and type extensions" begin
-    struct MyYield <: Yields.AbstractYield
+    struct MyYield <: Yields.AbstractYieldCurve
         rate
     end
 


### PR DESCRIPTION
Allows for more generic code (e.g. methods that want a rate or a curve, but not floats)