### PR TITLE
define `forward` on `Rate`s

### DIFF
--- a/src/AbstractYield.jl
+++ b/src/AbstractYield.jl
@@ -2,6 +2,7 @@
 An AbstractYield is an object which can be used as an argument to:
 
 - zero-coupon spot rates via [`zero`](@ref)
+- forward zero rates via [`forward`](@ref)
 - discount factor via [`discount`](@ref)
 - accumulation factor via [`accumulation`](@ref)
 

--- a/src/Rate.jl
+++ b/src/Rate.jl
@@ -228,7 +228,8 @@ accumulation(rate::Rate{<:Real, <:Periodic}, t) = (1 + rate.value / rate.compoun
 accumulation(rate, from, to) = accumulation(rate, to - from)
 
 Base.zero(rate::T,t) where {T<:Rate} = rate
-forward(rate::T,t) where {T<:Rate} = rate
+forward(rate::T,to) where {T<:Rate} = rate
+forward(rate::T,from,to) where {T<:Rate} = rate
 
 """
     +(Yields.Rate, T<:Real)

--- a/src/Rate.jl
+++ b/src/Rate.jl
@@ -228,6 +228,7 @@ accumulation(rate::Rate{<:Real, <:Periodic}, t) = (1 + rate.value / rate.compoun
 accumulation(rate, from, to) = accumulation(rate, to - from)
 
 Base.zero(rate::T,t) where {T<:Rate} = rate
+forward(rate::T,t) where {T<:Rate} = rate
 
 """
     +(Yields.Rate, T<:Real)

--- a/test/Rate.jl
+++ b/test/Rate.jl
@@ -72,6 +72,8 @@
 
         @test zero(c,2) ≈ c
         @test zero(p,2) ≈ p
+        @test forward(c,2) ≈ c
+        @test forward(p,2) ≈ p
 
         @test discount(c,2) ≈ exp(-2*0.03)
         @test discount(p,2) ≈ 1 / (1 + .04/2)^(2*2)


### PR DESCRIPTION
bugfix release b/c `forward` should have been defined as part of the interface