### PR TITLE
tag v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Yields"
 uuid = "d7e99b2f-e7f3-4d9e-9f01-2338fc023ad3"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
-version = "2.2.0"
+version = "3.0.0"
 
 [deps]
 BSplineKit = "093aae92-e908-43d7-9660-e50ee39d5a0a"


### PR DESCRIPTION
# Release Notes

## New Features

- The set of constructors that previously only provided a Bootstrapping method (now called `Bootsrap()`) now also allow `NelsonSiegel()` and `NelsonSiegelSvensson()` arguments (per @leeyuntien). These arguments will determine the method of fitting the rates to a curve. More [in the docs](https://juliaactuary.github.io/Yields.jl/stable/#Fitting-Curves-to-Rates)
  - The default method remains `Bootstrap(QuadraticSpline())`  
- There are more ways to construct and covert `Rate`s:
  - You can pass an argument to a `CompoundingFrequency` to create a corresponding `Rate` type. For example, `Continuous()(0.03)` or `Periodic(2)(0.03)` are valid method signatures.
  - Instead of calling `convert(Periodic(2), Continuous(0.03)`, you can simply convert by doing `Periodic(Continous(0.03),2)`

## Breaking Changes

- The `interpolation` function keyword argument is now passed as an argument to the `Bootstrap()` datatype.
- `Yields.Constant` no longer accepts a `(<:Real, CompoundingFrequency)` argument pair - you must pass a `Rate` or a `<:Real` will be interpreted with `Periodic(1)` frequency. 

## Other Changes

- `Yields.Par` and `Yields.par` is now more robust due to borrowing more robust routines for IRR solving from `ActuaryUtilities.jl`
- `Bootstrap`,`NelsonSiegel`,`NelsonSiegelSvensson`,`SmithWilson1 are now exported.
- The non-exported `BootstrappedYieldCurve` is now called `BootstrappedCurve` 
- More docstrings and details in docstrings have been added.
- Various methods have been made more generic and have had unnecessary parameterizations removed
- Precompile statements have been added which should improve user time after `using Yields`

## Other Fixes

- Yield curve fitting functions will now inherit the indices of the rate vector, generalizing for the case when passed a nonstandard array (i.e. with 1 to length indices)
- The `Step` curve rate constructor and methods 