### PR TITLE
let `Periodic` work for numbers approximately equal to integers

### DIFF
--- a/src/Rate.jl
+++ b/src/Rate.jl
@@ -38,7 +38,9 @@ end
 """ 
     Periodic(frequency)
 
-A type representing periodic interest compounding with the given frequency
+A type representing periodic interest compounding with the given frequency. 
+
+`frequency` will be converted to an `Integer`, and will round up to 8 decimal places (otherwise will throw an `InexactError`). 
 
 # Examples
 
@@ -54,6 +56,12 @@ See also: [`Continuous`](@ref)
 struct Periodic <: CompoundingFrequency
     frequency::Int
 end
+
+function Periodic(frequency::T) where {T<:AbstractFloat}
+    f = Int(round(frequency,digits=8))
+    Periodic(f)
+end
+
 
 function (p::Periodic)(r) 
     convert.(p, r)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ActuaryUtilities = "bdd23359-8b1c-4f88-b89b-d11982a786f4"
+DecFP = "55939f99-70c6-5e9b-8bb0-5071ed7d61fd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Yields = "d7e99b2f-e7f3-4d9e-9f01-2338fc023ad3"
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -37,3 +37,14 @@ end
     @test Yields.__coerce_rate(0.05, Periodic(1)) == Periodic(0.05,1)
     @test Yields.__coerce_rate(Periodic(0.05,12), Periodic(1)) == Periodic(0.05,12)
 end
+
+#Issue #117
+@testset "DecFP" begin
+    import DecFP
+
+    @test Yields.Periodic(1/DecFP.Dec64(1/6)) == Yields.Periodic(6)
+    mats = convert.(DecFP.Dec64,[1/12, 2/12, 3/12, 6/12, 1, 2, 3, 5, 7, 10, 20, 30])
+    rates = convert.(DecFP.Dec64,[0.01, 0.01, 0.03, 0.05, 0.07, 0.16, 0.35, 0.92, 1.40, 1.74, 2.31, 2.41] ./ 100)
+    y = Yields.CMT(rates,mats)
+    @test y isa Yields.AbstractYieldCurve
+end


### PR DESCRIPTION
closes #117 

e.g. `DecFP.Dec64(5.99999999999)` will now become `Periodic(6)` instead of `InexactError`