### PR TITLE
use SnoopPrecompile

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
@@ -20,10 +21,10 @@ FinanceCore = "^1"
 ForwardDiff = "^0.10"
 LsqFit = "^0.12"
 Optim = "^1"
+Reexport = "^1.2"
 Roots = "^1"
 UnicodePlots = "^2"
 julia = "^1.6"
-Reexport = "^1.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Yields.jl
+++ b/src/Yields.jl
@@ -1,6 +1,7 @@
 module Yields
 
 using Reexport
+using SnoopPrecompile
 using FinanceCore
 using FinanceCore: Rate, rate, discount, accumulation, Periodic, Continuous, forward
 @reexport using FinanceCore: Rate, rate, discount, accumulation, Periodic, Continuous, forward 

--- a/src/precompiles.jl
+++ b/src/precompiles.jl
@@ -1,9 +1,15 @@
-function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
 
-    let 
-        rates = [0.057, 0.0755, 0.0837, 0.078, 0.1084, 0.0702, 0.1167]
-        tenors = [1,3,5,10,15,20,25]
+# created with the help of SnoopCompile.jl
+@precompile_setup begin
+
+    
+    # 2021-03-31 rates from Treasury.gov
+    rates =[0.01, 0.01, 0.03, 0.05, 0.07, 0.16, 0.35, 0.92, 1.40, 1.74, 2.31, 2.41] ./ 100
+    tenors = [1/12, 2/12, 3/12, 6/12, 1, 2, 3, 5, 7, 10, 20, 30]
+
+    @precompile_all_calls begin
+        # all calls in this block will be precompiled, regardless of whether
+        # they belong to your package or not (on Julia 1.8 and higher)
         Yields.Par(rates,tenors)
         Yields.CMT(rates,tenors)
         Yields.Forward(rates,tenors)
@@ -16,17 +22,5 @@ function _precompile_()
         Yields.par(c,10)
         Yields.forward(c,5,6)
     end
-    let 
-        rates = [0.057, 0.0755, 0.0837, 0.078, 0.1084, 0.0702, 0.1167]
-        tenors = [1.0,3,5,10,15,20,25]
-        Yields.Par(rates,tenors)
-        Yields.CMT(rates,tenors)
-        Yields.Forward(rates,tenors)
-        Yields.OIS(rates,tenors)
-        Yields.Zero(rates,tenors)
-        Yields.Zero(NelsonSiegel(), rates,tenors)
-        Yields.Zero(NelsonSiegelSvensson(), rates,tenors)
-                
-    end
-    
+        
 end


### PR DESCRIPTION
Faster TTFX:

```julia
@time let
using Yields
  rates =[0.01, 0.01, 0.03, 0.05, 0.07, 0.16, 0.35, 0.92, 1.40, 1.74, 2.31, 2.41] ./ 100
  mats = [1/12, 2/12, 3/12, 6/12, 1, 2, 3, 5, 7, 10, 20, 30]
  
  Yields.CMT(rates,mats)
end
```

Before:

```
7.073677 seconds (35.05 M allocations: 2.267 GiB, 6.13% gc time, 35.60% compilation time: 9% of which was recompilation)
```

After:
```
5.814652 seconds (22.84 M allocations: 1.640 GiB, 5.09% gc time, 15.12% compilation time: 17% of which was recompilation)
```