### PR TITLE
DateModel

### DIFF
--- a/src/model/Model.jl
+++ b/src/model/Model.jl
@@ -5,6 +5,11 @@ Base.Broadcast.broadcastable(x::T) where {T<:AbstractModel} = Ref(x)
 # (e.g. determining nominal cashflows for fixed income contract)
 struct NullModel <: AbstractModel end
 
+struct DateModel{M,T} <: AbstractModel
+    model::M
+    date::T
+end
+
 # useful for round-tripping or iterating on quotes?
 function Quote(m::M, c::C) where {M<:AbstractModel,C<:FinanceCore.AbstractContract}
     return Quote(pv(m, c), c)


### PR DESCRIPTION
Contracts already use FinanceCore.Timepoint... which is simply `Union{Date,<:Real)`. This PR on the main PR would:

- Define a `DateModel` which has two fields: a `model` (same model you would otherwise use in a `Projection` and `valuation_date`
- in various logic, use dispatch combining the underlying type within the contract and the `model` to determine the decimal time (yearfrac) relative to the val date in the `DateModel`
- Use BusinessDays, DayCounts, and logic from Miletus to determine dates of cashflows for real date bonds 